### PR TITLE
Fix typos2

### DIFF
--- a/Mods/CaveworldFlora_SK/Defs/ThingDefs/Buildings_FungiponicsBasin.xml
+++ b/Mods/CaveworldFlora_SK/Defs/ThingDefs/Buildings_FungiponicsBasin.xml
@@ -16,7 +16,7 @@
 
   <ThingDef ParentName="BuildingBase">
     <defName>FungiponicsBasin</defName>
-    <label>fungiponics basin</label>
+    <label>Fungiponics Basin</label>
     <thingClass>CaveworldFlora.Building_FungiponicsBasin</thingClass>
     <graphicData>
       <texPath>Things/Building/Production/FungiponicsBasin</texPath>

--- a/Mods/Clutter_SK/Defs/ThingDefs/Furniture.xml
+++ b/Mods/Clutter_SK/Defs/ThingDefs/Furniture.xml
@@ -84,8 +84,8 @@
   
   <ThingDef Class="Clutter_Furniture.ClutterThingDefs" ParentName="FurnitureBase">
     <defName>ClutterEkieBed</defName>
-    <label>Sleeping pod</label>
-    <Description>Redesigned cryo pod.</Description>
+    <label>Sleeping Pod</label>
+    <Description>A cryogenic stasis pod which has been repurposed into a bed.</Description>
     <ThingClass>Clutter_Furniture.Beds</ThingClass>
     <graphicData>
       <texPath>Clutter/Beds/EkieBed/MBed</texPath>

--- a/Mods/Core/Defs/ResearchProjectDefs/ResearchProjects_Tier2_Misc.xml
+++ b/Mods/Core/Defs/ResearchProjectDefs/ResearchProjects_Tier2_Misc.xml
@@ -7,7 +7,7 @@
   <ResearchProjectDef>
     <defName>Firefoam</defName>
     <label>firefoam</label>
-    <description>Allows the construction of firefoam poppers; fire-safety buildings which spread fire-retardant foam in response to encroaching flames.</description>
+    <description>Allows the construction of Firefoam Poppers; fire-safety buildings which spread fire-retardant foam in response to encroaching flames.</description>
     <totalCost>800</totalCost>
     <requiredResearchBuilding>HiTechResearchBench</requiredResearchBuilding>
   </ResearchProjectDef>

--- a/Mods/Core/Defs/ThingDefs_Buildings/Buildings_Furniture.xml
+++ b/Mods/Core/Defs/ThingDefs_Buildings/Buildings_Furniture.xml
@@ -123,7 +123,7 @@
 
   <ThingDef ParentName="HighQualityFurnitureBase">
     <defName>DoubleBed</defName>
-    <label>double bed</label>
+    <label>Double Bed</label>
     <Description>A simple double-wide bed that fits two people.</Description>
     <ThingClass>Building_Bed</ThingClass>
     <graphicData>
@@ -411,7 +411,7 @@
 
   <ThingDef ParentName="FurnitureBase">
     <defName>Stool</defName>
-    <label>stool</label>
+    <label>Stool</label>
     <graphicData>
       <texPath>Things/Building/Furniture/Stool</texPath>
       <graphicClass>Graphic_Multi</graphicClass>

--- a/Mods/Core/Defs/ThingDefs_Buildings/Buildings_Misc.xml
+++ b/Mods/Core/Defs/ThingDefs_Buildings/Buildings_Misc.xml
@@ -321,7 +321,7 @@
   
   <ThingDef ParentName="BuildingBase">
     <defName>FirefoamPopper</defName>
-    <label>firefoam popper</label>
+    <label>Firefoam Popper</label>
     <thingClass>Building_FirefoamPopper</thingClass>
     <description>When touched by fire or triggered by hand, this pops and sprays a fire-extinguishing foam in a circular field around itself.</description>
     <graphicData>
@@ -600,7 +600,7 @@
 
   <ThingDef ParentName="BuildingBase">
     <defName>MarriageSpot</defName>
-    <label>marriage spot</label>
+    <label>Marriage Spot</label>
     <Description>Designates a spot where marriage ceremonies will take place. Spectators can watch from either side.</Description>
     <graphicData>
       <texPath>Things/Building/Misc/MarriageSpot</texPath>
@@ -624,7 +624,7 @@
   
   <ThingDef ParentName="BuildingBase">
     <defName>PartySpot</defName>
-    <label>party spot</label>
+    <label>Party Spot</label>
     <Description>Designates a spot where parties will be centered. Parties use an area around the spot.</Description>
     <graphicData>
       <texPath>Things/Building/Misc/PartySpot</texPath>

--- a/Mods/Core/Defs/ThingDefs_Buildings/Buildings_Production.xml
+++ b/Mods/Core/Defs/ThingDefs_Buildings/Buildings_Production.xml
@@ -3,7 +3,7 @@
 
   <ThingDef ParentName="BuildingBase">
     <defName>CraftingSpot</defName>
-    <label>crafting spot</label>
+    <label>Crafting Spot</label>
     <Description>A place for crafting simple things like shivs or bows.</Description>
     <ThingClass>Building_WorkTable</ThingClass>
     <graphicData>

--- a/Mods/Core/Defs/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Mods/Core/Defs/ThingDefs_Buildings/Buildings_Security.xml
@@ -319,7 +319,7 @@
 
   <ThingDef ParentName="BuildingBase">
     <defName>TrapDeadfall</defName>
-    <label>deadfall trap</label>
+    <label>Deadfall Trap</label>
     <thingClass>Building_TrapRearmable</thingClass>
     <graphicData>
       <texPath>Things/Building/Security/DeadfallArmed</texPath>
@@ -363,7 +363,7 @@
 
   <ThingDef ParentName="BuildingBase">
     <defName>TrapIEDBomb</defName>
-    <label>IED trap</label>
+    <label>IED Trap</label>
     <thingClass>Building_TrapExplosive</thingClass>
     <graphicData>
       <texPath>Things/Building/Security/IEDBomb</texPath>
@@ -410,7 +410,7 @@
 
   <ThingDef ParentName="BuildingBase">
     <defName>TrapIEDIncendiary</defName>
-    <label>IED incendiary trap</label>
+    <label>IED Incendiary Trap</label>
     <thingClass>Building_TrapExplosive</thingClass>
     <graphicData>
       <texPath>Things/Building/Security/IEDIncendiary</texPath>

--- a/Mods/Core/Defs/ThingDefs_Buildings/Buildings_Structure.xml
+++ b/Mods/Core/Defs/ThingDefs_Buildings/Buildings_Structure.xml
@@ -51,7 +51,7 @@
 
   <ThingDef ParentName="DoorBase">
     <defName>Door</defName>
-    <label>door</label>
+    <label>Door</label>
     <description>Divides rooms. Must be manually opened and closed, which slows people down.</description>
     <statBases>
       <WorkToMake>850</WorkToMake>
@@ -109,7 +109,7 @@
 
   <ThingDef ParentName="BuildingBase" Name="Wall">
     <defName>Wall</defName>
-    <label>wall</label>
+    <label>Wall</label>
     <thingClass>Building</thingClass>
     <category>Building</category>
     <description>An impassable wall. Capable of holding up a roof.</description>

--- a/Mods/Core/Languages/English/Keyed/Misc_Gameplay.xml
+++ b/Mods/Core/Languages/English/Keyed/Misc_Gameplay.xml
@@ -292,7 +292,7 @@
   <!-- Artifact -->
   <UseArtifact>Activate</UseArtifact>
   
-  <!-- Firefoam popper -->
+  <!-- Firefoam Popper -->
   <TriggerFirefoamPopper>Trigger firefoam popper</TriggerFirefoamPopper>
   
   <!-- Minification -->

--- a/Mods/Core/Languages/Russian-SK/Keyed/Misc_Gameplay.xml
+++ b/Mods/Core/Languages/Russian-SK/Keyed/Misc_Gameplay.xml
@@ -292,7 +292,7 @@
    <!-- Artifact -->
   <UseArtifact>Активировать</UseArtifact>
   
-  <!-- Firefoam popper -->
+  <!-- Firefoam Popper -->
   <TriggerFirefoamPopper>Срабатывание пожарного гидранта</TriggerFirefoamPopper>
 
   <!-- Minification -->

--- a/Mods/Core_SK/Defs/TerrainDefs/Terrain_Floors_SK.xml
+++ b/Mods/Core_SK/Defs/TerrainDefs/Terrain_Floors_SK.xml
@@ -483,7 +483,7 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="MetalPlateBase">
 		<DefName>PlateCopperBar</DefName>
-		<label>Copper plates</label>
+		<label>Copper Plates</label>
 		<color>(160,115,45)</color>
 		<CostList>
 			<CopperBar>4</CopperBar>
@@ -491,7 +491,7 @@ Beauty: 3.</Description>
 	</TerrainDef>
 	<TerrainDef ParentName="MetalPlateBase">
 		<DefName>PlateSilver</DefName>
-		<label>Silver plated plates</label>
+		<label>Silver-plated Plates</label>
 		<color>(180,173,150)</color>
 		<CostList>
 			<SilverBar>4</SilverBar>
@@ -500,7 +500,7 @@ Beauty: 3.</Description>
 	</TerrainDef>
 	<TerrainDef ParentName="MetalPlateBase">
 		<DefName>PlateGold</DefName>
-		<label>Gold plated plates</label>
+		<label>Gold-plated Plates</label>
 		<color>(255,235,122)</color>
 		<CostList>
 			<GoldBar>3</GoldBar>
@@ -509,7 +509,7 @@ Beauty: 3.</Description>
 	</TerrainDef>
 	<TerrainDef ParentName="MetalPlateBase">
 		<DefName>PlateSteel</DefName>
-		<label>Steel plates</label>
+		<label>Steel Plates</label>
 		<color>(128,128,128)</color>
 		<CostList>
 			<SteelBar>4</SteelBar>
@@ -517,7 +517,7 @@ Beauty: 3.</Description>
 	</TerrainDef>
 	<TerrainDef ParentName="MetalPlateBase">
 		<DefName>PlateKovar</DefName>
-		<label>Kovar plates</label>
+		<label>Kovar Plates</label>
 		<color>(0,107,183)</color>
 		<CostList>
 			<CobaltIronAlloy>4</CobaltIronAlloy>
@@ -525,7 +525,7 @@ Beauty: 3.</Description>
 	</TerrainDef>
 	<TerrainDef ParentName="MetalPlateBase">
 		<DefName>PlateCupronickelAlloy</DefName>
-		<label>Melchior plates</label>
+		<label>Melchior Plates</label>
 		<color>(168,157,125)</color>
 		<CostList>
 			<CupronickelAlloy>4</CupronickelAlloy>
@@ -533,7 +533,7 @@ Beauty: 3.</Description>
 	</TerrainDef>
 	<TerrainDef ParentName="MetalPlateBase">
 		<DefName>PlateNichromeAlloy</DefName>
-		<label>Nichrome plates</label>
+		<label>Nichrome Plates</label>
 		<color>(210,210,210)</color>
 		<CostList>
 			<NichromeAlloy>4</NichromeAlloy>
@@ -1109,7 +1109,7 @@ Beauty: 10.</Description>
 
 	<TerrainDef ParentName="MediumBrickBase">
 		<DefName>MBrickSandstone</DefName>
-		<label>sandstone bricks</label>
+		<label>Sandstone Bricks</label>
 		<color>(126,104,94)</color>
 		<CostList>
 			<BlocksSandstone>4</BlocksSandstone>
@@ -1117,7 +1117,7 @@ Beauty: 10.</Description>
 	</TerrainDef>
 	<TerrainDef ParentName="MediumBrickBase">
 		<DefName>MBrickGranite</DefName>
-		<label>granite bricks</label>
+		<label>Granite Bricks</label>
 		<color>(105,95,97)</color>
 		<CostList>
 			<BlocksGranite>4</BlocksGranite>
@@ -1125,7 +1125,7 @@ Beauty: 10.</Description>
 	</TerrainDef>
 	<TerrainDef ParentName="MediumBrickBase">
 		<DefName>MBrickLimestone</DefName>
-		<label>limestone bricks</label>
+		<label>Limestone Bricks</label>
 		<color>(158,153,135)</color>
 		<CostList>
 			<BlocksLimestone>4</BlocksLimestone>
@@ -1133,7 +1133,7 @@ Beauty: 10.</Description>
 	</TerrainDef>
 	<TerrainDef ParentName="MediumBrickBase">
 		<DefName>MBrickSlate</DefName>
-		<label>slate bricks</label>
+		<label>Slate Bricks</label>
 		<color>(70,70,70)</color>
 		<CostList>
 			<BlocksSlate>4</BlocksSlate>
@@ -1141,7 +1141,7 @@ Beauty: 10.</Description>
 	</TerrainDef>
 	<TerrainDef ParentName="MediumBrickBase">
 		<DefName>MBrickMarble</DefName>
-		<label>marble bricks</label>
+		<label>Marble Bricks</label>
 		<color>(132,135,132)</color>
 		<CostList>
 			<BlocksMarble>4</BlocksMarble>
@@ -1152,7 +1152,7 @@ Beauty: 10.</Description>
 
 	<TerrainDef ParentName="SmallBrickBase">
 		<DefName>SBrickSandstone</DefName>
-		<label>sandstone small bricks</label>
+		<label>Sandstone Small bricks</label>
 		<color>(126,104,94)</color>
 		<CostList>
 			<BlocksSandstone>4</BlocksSandstone>
@@ -1160,7 +1160,7 @@ Beauty: 10.</Description>
 	</TerrainDef>
 	<TerrainDef ParentName="SmallBrickBase">
 		<DefName>SBrickGranite</DefName>
-		<label>granite small bricks</label>
+		<label>Granite Small bricks</label>
 		<color>(105,95,97)</color>
 		<CostList>
 			<BlocksGranite>4</BlocksGranite>
@@ -1168,7 +1168,7 @@ Beauty: 10.</Description>
 	</TerrainDef>
 	<TerrainDef ParentName="SmallBrickBase">
 		<DefName>SBrickLimestone</DefName>
-		<label>limestone small bricks</label>
+		<label>Limestone Small Bricks</label>
 		<color>(158,153,135)</color>
 		<CostList>
 			<BlocksLimestone>4</BlocksLimestone>
@@ -1176,7 +1176,7 @@ Beauty: 10.</Description>
 	</TerrainDef>
 	<TerrainDef ParentName="SmallBrickBase">
 		<DefName>SBrickSlate</DefName>
-		<label>slate small bricks</label>
+		<label>Slate Small Bricks</label>
 		<color>(70,70,70)</color>
 		<CostList>
 			<BlocksSlate>4</BlocksSlate>
@@ -1184,7 +1184,7 @@ Beauty: 10.</Description>
 	</TerrainDef>
 	<TerrainDef ParentName="SmallBrickBase">
 		<DefName>SBrickMarble</DefName>
-		<label>marble small bricks</label>
+		<label>Marble Small Bricks</label>
 		<color>(132,135,132)</color>
 		<CostList>
 			<BlocksMarble>4</BlocksMarble>
@@ -1195,7 +1195,7 @@ Beauty: 10.</Description>
 
 	<TerrainDef ParentName="MedBrickBase">
 		<DefName>MedBrickSandstone</DefName>
-		<label>sandstone Mediterranean bricks</label>
+		<label>Sandstone Mediterranean Bricks</label>
 		<color>(126,104,94)</color>
 		<CostList>
 			<BlocksSandstone>4</BlocksSandstone>
@@ -1203,7 +1203,7 @@ Beauty: 10.</Description>
 	</TerrainDef>
 	<TerrainDef ParentName="MedBrickBase">
 		<DefName>MedBrickGranite</DefName>
-		<label>granite Mediterranean bricks</label>
+		<label>Granite Mediterranean Bricks</label>
 		<color>(105,95,97)</color>
 		<CostList>
 			<BlocksGranite>4</BlocksGranite>
@@ -1211,7 +1211,7 @@ Beauty: 10.</Description>
 	</TerrainDef>
 	<TerrainDef ParentName="MedBrickBase">
 		<DefName>MedBrickLimestone</DefName>
-		<label>limestone Mediterranean bricks</label>
+		<label>Limestone Mediterranean Bricks</label>
 		<color>(158,153,135)</color>
 		<CostList>
 			<BlocksLimestone>4</BlocksLimestone>
@@ -1219,7 +1219,7 @@ Beauty: 10.</Description>
 	</TerrainDef>
 	<TerrainDef ParentName="MedBrickBase">
 		<DefName>MedBrickSlate</DefName>
-		<label>slate Mediterranean bricks</label>
+		<label>Slate Mediterranean Bricks</label>
 		<color>(70,70,70)</color>
 		<CostList>
 			<BlocksSlate>4</BlocksSlate>
@@ -1227,7 +1227,7 @@ Beauty: 10.</Description>
 	</TerrainDef>
 	<TerrainDef ParentName="MedBrickBase">
 		<DefName>MedBrickMarble</DefName>
-		<label>marble Mediterranean bricks</label>
+		<label>Marble Mediterranean Bricks</label>
 		<color>(132,135,132)</color>
 		<CostList>
 			<BlocksMarble>4</BlocksMarble>
@@ -1236,27 +1236,27 @@ Beauty: 10.</Description>
 
 	<TerrainDef ParentName="CobblestoneBase">
 		<DefName>CobbleFloorSandstone</DefName>
-		<label>sandstone cobble floor</label>
+		<label>Sandstone Cobble Floor</label>
 		<color>(126,104,94)</color>
 	</TerrainDef>	
 	<TerrainDef ParentName="CobblestoneBase">
 		<DefName>CobbleFloorGranite</DefName>
-		<label>granite cobble floor</label>
+		<label>Granite Cobble Floor</label>
 		<color>(105,95,97)</color>
 	</TerrainDef>	
 	<TerrainDef ParentName="CobblestoneBase">
 		<DefName>CobbleFloorLimestone</DefName>
-		<label>limestone cobble floor</label>
+		<label>Limestone Cobble Floor</label>
 		<color>(158,153,135)</color>
 	</TerrainDef>	
 	<TerrainDef ParentName="CobblestoneBase">
 		<DefName>CobbleFloorSlate</DefName>
-		<label>slate cobble floor</label>
+		<label>Slate Cobble Floor</label>
 		<color>(70,70,70)</color>
 	</TerrainDef>	
 	<TerrainDef ParentName="CobblestoneBase">
 		<DefName>CobbleFloorMarble</DefName>
-		<label>marble cobble floor</label>
+		<label>Marble Cobble Floor</label>
 		<color>(132,135,132)</color>
 	</TerrainDef>	
 
@@ -1264,7 +1264,7 @@ Beauty: 10.</Description>
 
 	<TerrainDef ParentName="BrickUnevenBase">
 		<DefName>UEBrickSandstone</DefName>
-		<label>sandstone uneven bricks</label>
+		<label>Sandstone Uneven Bricks</label>
 		<color>(126,104,94)</color>
 		<CostList>
 			<BlocksSandstone>4</BlocksSandstone>
@@ -1272,7 +1272,7 @@ Beauty: 10.</Description>
 	</TerrainDef>
 	<TerrainDef ParentName="BrickUnevenBase">
 		<DefName>UEBrickGranite</DefName>
-		<label>granite uneven bricks</label>
+		<label>Granite Uneven Bricks</label>
 		<color>(105,95,97)</color>
 		<CostList>
 			<BlocksGranite>4</BlocksGranite>
@@ -1280,7 +1280,7 @@ Beauty: 10.</Description>
 	</TerrainDef>
 	<TerrainDef ParentName="BrickUnevenBase">
 		<DefName>UEBrickLimestone</DefName>
-		<label>limestone uneven bricks</label>
+		<label>Limestone Uneven Bricks</label>
 		<color>(158,153,135)</color>
 		<CostList>
 			<BlocksLimestone>4</BlocksLimestone>
@@ -1288,7 +1288,7 @@ Beauty: 10.</Description>
 	</TerrainDef>
 	<TerrainDef ParentName="BrickUnevenBase">
 		<DefName>UEBrickSlate</DefName>
-		<label>slate uneven bricks</label>
+		<label>Slate Uneven Bricks</label>
 		<color>(70,70,70)</color>
 		<CostList>
 			<BlocksSlate>4</BlocksSlate>
@@ -1296,7 +1296,7 @@ Beauty: 10.</Description>
 	</TerrainDef>
 	<TerrainDef ParentName="BrickUnevenBase">
 		<DefName>UEBrickMarble</DefName>
-		<label>marble uneven bricks</label>
+		<label>Marble Uneven Bricks</label>
 		<color>(132,135,132)</color>
 		<CostList>
 			<BlocksMarble>4</BlocksMarble>
@@ -1307,7 +1307,7 @@ Beauty: 10.</Description>
 
 	<TerrainDef ParentName="StoneTileBase">
 		<DefName>EXF_TileSandstone</DefName>
-		<label>sandstone tiles</label>
+		<label>Sandstone Tiles</label>
 		<color>(126,104,94)</color>
 		<CostList>
 			<BlocksSandstone>4</BlocksSandstone>
@@ -1315,7 +1315,7 @@ Beauty: 10.</Description>
 	</TerrainDef>
 	<TerrainDef ParentName="StoneTileBase">
 		<DefName>EXF_TileGranite</DefName>
-		<label>granite tiles</label>
+		<label>Granite Tiles</label>
 		<color>(105,95,97)</color>
 		<CostList>
 			<BlocksGranite>4</BlocksGranite>
@@ -1323,7 +1323,7 @@ Beauty: 10.</Description>
 	</TerrainDef>
 	<TerrainDef ParentName="StoneTileBase">
 		<DefName>EXF_TileLimestone</DefName>
-		<label>limestone tiles</label>
+		<label>Limestone Tiles</label>
 		<color>(158,153,135)</color>
 		<CostList>
 			<BlocksLimestone>4</BlocksLimestone>
@@ -1331,7 +1331,7 @@ Beauty: 10.</Description>
 	</TerrainDef>
 	<TerrainDef ParentName="StoneTileBase">
 		<DefName>EXF_TileSlate</DefName>
-		<label>slate tiles</label>
+		<label>Slate Tiles</label>
 		<color>(70,70,70)</color>
 		<CostList>
 			<BlocksSlate>4</BlocksSlate>
@@ -1339,7 +1339,7 @@ Beauty: 10.</Description>
 	</TerrainDef>
 	<TerrainDef ParentName="StoneTileBase">
 		<DefName>EXF_TileMarble</DefName>
-		<label>marble tiles</label>
+		<label>Marble Tiles</label>
 		<color>(132,135,132)</color>
 		<CostList>
 			<BlocksMarble>4</BlocksMarble>
@@ -1350,7 +1350,7 @@ Beauty: 10.</Description>
 
 	<TerrainDef ParentName="BrickHerringboneBase">
 		<DefName>HerrBrickSandstone</DefName>
-		<label>sandstone herringbone bricks</label>
+		<label>Sandstone Herringbone Bricks</label>
 		<color>(126,104,94)</color>
 		<CostList>
 			<BlocksSandstone>4</BlocksSandstone>
@@ -1358,7 +1358,7 @@ Beauty: 10.</Description>
 	</TerrainDef>
 	<TerrainDef ParentName="BrickHerringboneBase">
 		<DefName>HerrBrickGranite</DefName>
-		<label>granite herringbone bricks</label>
+		<label>Granite Herringbone Bricks</label>
 		<color>(105,95,97)</color>
 		<CostList>
 			<BlocksGranite>4</BlocksGranite>
@@ -1366,7 +1366,7 @@ Beauty: 10.</Description>
 	</TerrainDef>
 	<TerrainDef ParentName="BrickHerringboneBase">
 		<DefName>HerrBrickLimestone</DefName>
-		<label>limestone herringbone bricks</label>
+		<label>Limestone Herringbone Bricks</label>
 		<color>(158,153,135)</color>
 		<CostList>
 			<BlocksLimestone>4</BlocksLimestone>
@@ -1374,7 +1374,7 @@ Beauty: 10.</Description>
 	</TerrainDef>
 	<TerrainDef ParentName="BrickHerringboneBase">
 		<DefName>HerrBrickSlate</DefName>
-		<label>slate herringbone bricks</label>
+		<label>Slate Herringbone Bricks</label>
 		<color>(70,70,70)</color>
 		<CostList>
 			<BlocksSlate>4</BlocksSlate>
@@ -1382,7 +1382,7 @@ Beauty: 10.</Description>
 	</TerrainDef>
 	<TerrainDef ParentName="BrickHerringboneBase">
 		<DefName>HerrBrickMarble</DefName>
-		<label>marble herringbone bricks</label>
+		<label>Marble Herringbone Bricks</label>
 		<color>(132,135,132)</color>
 		<CostList>
 			<BlocksMarble>4</BlocksMarble>
@@ -1543,7 +1543,7 @@ Beauty: -1.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<DefName>FloorStoneSlabsSandstone</DefName>
-		<Label>Stone Slabs (Sandstone)</Label>
+		<Label>Sandstone Stone Slabs</Label>
 		<color>(126,104,94)</color>
 		<RenderPrecedence>270</RenderPrecedence>
 		<Description>Stone flooring made with square slabs. Sandstone version. 
@@ -1558,7 +1558,7 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<DefName>FloorStoneSlabsGranite</DefName>
-		<Label>Stone Slabs (Granite)</Label>
+		<Label>Granite Stone Slabs</Label>
 		<color>(105,95,97)</color>
 		<RenderPrecedence>270</RenderPrecedence>
 		<Description>Stone flooring made with square slabs. Granite version.
@@ -1573,7 +1573,7 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<DefName>FloorStoneSlabsLimestone</DefName>
-		<Label>Stone Slabs (Limestone)</Label>
+		<Label>Limestone Stone Slabs</Label>
 		<color>(158,153,135)</color>
 		<RenderPrecedence>270</RenderPrecedence>
 		<Description>Stone flooring made with square slabs. Limestone version. 
@@ -1588,7 +1588,7 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<DefName>FloorStoneSlabsSlate</DefName>
-		<Label>Stone Slabs (Slate)</Label>
+		<Label>Slate Stone Slabs</Label>
 		<color>(70,70,70)</color>
 		<RenderPrecedence>270</RenderPrecedence>
 		<Description>Stone flooring made with square slabs. Slate version. 
@@ -1603,7 +1603,7 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<DefName>FloorStoneSlabsMarble</DefName>
-		<Label>Stone Slabs (Marble)</Label>
+		<Label>Marble Stone Slabs</Label>
 		<color>(132,135,132)</color>
 		<RenderPrecedence>270</RenderPrecedence>
 		<Description>Stone flooring made with square slabs. Marble version. 
@@ -1620,10 +1620,10 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneHexSandstone</defName>
-		<Label>Hex Paving (Sandstone)</Label>
+		<Label>Sandstone Hex Pavers</Label>
 		<color>(126,104,94)</color>
 		<RenderPrecedence>269</RenderPrecedence>
-		<Description>Stone paving with hexagonal tiles. Sandstone version. 
+		<Description>Stone pavers cut into a hexagon shape. Sandstone version. 
 Beauty: 3.</Description>
 		<texturePath>Terrain/Surfaces/StoneHex</texturePath>
 		<researchPrerequisites><li>FloorArtIV</li></researchPrerequisites>
@@ -1635,10 +1635,10 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneHexGranite</defName>
-		<Label>Hex Paving (Granite)</Label>
+		<Label>Granite Hex Pavers</Label>
 		<color>(105,95,97)</color>
 		<RenderPrecedence>269</RenderPrecedence>
-		<Description>Stone paving with hexagonal tiles. Granite version. 
+		<Description>Stone pavers cut into a hexagon shape. Granite version. 
 Beauty: 3.</Description>
 		<texturePath>Terrain/Surfaces/StoneHex</texturePath>
 		<researchPrerequisites><li>FloorArtIV</li></researchPrerequisites>
@@ -1650,10 +1650,10 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneHexLimestone</defName>
-		<Label>Hex Paving (Limestone)</Label>
+		<Label>Limestone Hex Pavers</Label>
 		<color>(158,153,135)</color>
 		<RenderPrecedence>269</RenderPrecedence>
-		<Description>Stone paving with hexagonal tiles. Limestone version. 
+		<Description>Stone pavers cut into a hexagon shape. Limestone version. 
 Beauty: 3.</Description>
 		<texturePath>Terrain/Surfaces/StoneHex</texturePath>
 		<researchPrerequisites><li>FloorArtIV</li></researchPrerequisites>
@@ -1665,10 +1665,10 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneHexSlate</defName>
-		<Label>Hex Paving (Slate)</Label>
+		<Label>Slate Hex Pavers</Label>
 		<color>(70,70,70)</color>
 		<RenderPrecedence>269</RenderPrecedence>
-		<Description>Stone paving with hexagonal tiles. Slate version. 
+		<Description>Stone pavers cut into a hexagon shape. Slate version. 
 Beauty: 3.</Description>
 		<texturePath>Terrain/Surfaces/StoneHex</texturePath>
 		<researchPrerequisites><li>FloorArtIV</li></researchPrerequisites>
@@ -1680,10 +1680,10 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneHexMarble</defName>
-		<Label>Hex Paving (Marble)</Label>
+		<Label>Marble Hex Pavers</Label>
 		<color>(132,135,132)</color>
 		<RenderPrecedence>269</RenderPrecedence>
-		<Description>Stone paving with hexagonal tiles. Marble version. 
+		<Description>Stone pavers cut into a hexagon shape. Marble version. 
 Beauty: 3.</Description>
 		<texturePath>Terrain/Surfaces/StoneHex</texturePath>
 		<researchPrerequisites><li>FloorArtIV</li></researchPrerequisites>
@@ -1697,10 +1697,10 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneMosaicSandstone</defName>
-		<Label>Mosaic Paving (Sandstone)</Label>
+		<Label>Sandstone Mosiac Pavers</Label>
 		<color>(126,104,94)</color>
 		<RenderPrecedence>268</RenderPrecedence>
-		<Description>Stone paving with a light/dark mosaic. Sandstone version. 
+		<Description>Stone pavers with a light/dark mosaic. Sandstone version. 
 Beauty: 3.</Description>
 		<texturePath>Terrain/Surfaces/StoneMosaic</texturePath>
 		<researchPrerequisites><li>FloorArtIV</li></researchPrerequisites>
@@ -1712,10 +1712,10 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneMosaicGranite</defName>
-		<Label>Mosaic Paving (Granite)</Label>
+		<Label>Granite Mosiac Pavers</Label>
 		<color>(105,95,97)</color>
 		<RenderPrecedence>268</RenderPrecedence>
-		<Description>Stone paving with a light/dark mosaic. Granite version. 
+		<Description>Stone pavers with a light/dark mosaic. Granite version. 
 Beauty: 3.</Description>
 		<texturePath>Terrain/Surfaces/StoneMosaic</texturePath>
 		<researchPrerequisites><li>FloorArtIV</li></researchPrerequisites>
@@ -1727,10 +1727,10 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneMosaicLimestone</defName>
-		<Label>Mosaic Paving (Limestone)</Label>
+		<Label>Limestone Mosiac Pavers</Label>
 		<color>(158,153,135)</color>
 		<RenderPrecedence>268</RenderPrecedence>
-		<Description>Stone paving with a light/dark mosaic. Limestone version. 
+		<Description>Stone pavers with a light/dark mosaic. Limestone version. 
 Beauty: 3.</Description>
 		<texturePath>Terrain/Surfaces/StoneMosaic</texturePath>
 		<researchPrerequisites><li>FloorArtIV</li></researchPrerequisites>
@@ -1742,10 +1742,10 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneMosaicSlate</defName>
-		<Label>Mosaic Paving (Slate)</Label>
+		<Label>Slate Mosiac Pavers</Label>
 		<color>(70,70,70)</color>
 		<RenderPrecedence>268</RenderPrecedence>
-		<Description>Stone paving with a light/dark mosaic. Slate version. 
+		<Description>Stone pavers with a light/dark mosaic. Slate version. 
 Beauty: 3.</Description>
 		<texturePath>Terrain/Surfaces/StoneMosaic</texturePath>
 		<researchPrerequisites><li>FloorArtIV</li></researchPrerequisites>
@@ -1757,10 +1757,10 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneMosaicMarble</defName>
-		<Label>Mosaic Paving (Marble)</Label>
+		<Label>Marble Mosiac Pavers</Label>
 		<color>(132,135,132)</color>
 		<RenderPrecedence>268</RenderPrecedence>
-		<Description>Stone paving with a light/dark mosaic. Marble version. 
+		<Description>Stone pavers with a light/dark mosaic. Marble version. 
 Beauty: 3.</Description>
 		<texturePath>Terrain/Surfaces/StoneMosaic</texturePath>
 		<researchPrerequisites><li>FloorArtIV</li></researchPrerequisites>
@@ -1774,10 +1774,10 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneRoughSandstone</defName>
-		<Label>Rough Paving (Sandstone)</Label>
+		<Label>Sandstone Rough Pavers</Label>
 		<color>(126,104,94)</color>
 		<RenderPrecedence>267</RenderPrecedence>
-		<Description>Rough stone paving. Sandstone version. 
+		<Description>Rough stone pavers. Sandstone version. 
 Beauty: 3.</Description>
 		<texturePath>Terrain/Surfaces/StoneRough</texturePath>
 		<researchPrerequisites><li>FloorArt</li></researchPrerequisites>
@@ -1789,10 +1789,10 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneRoughGranite</defName>
-		<Label>Rough Paving (Granite)</Label>
+		<Label>Granite Rough Pavers</Label>
 		<color>(105,95,97)</color>
 		<RenderPrecedence>267</RenderPrecedence>
-		<Description>Rough stone paving. Granite version. 
+		<Description>Rough stone pavers. Granite version. 
 Beauty: 3.</Description>
 		<texturePath>Terrain/Surfaces/StoneRough</texturePath>
 		<researchPrerequisites><li>FloorArt</li></researchPrerequisites>
@@ -1804,10 +1804,10 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneRoughLimestone</defName>
-		<Label>Rough Paving (Limestone)</Label>
+		<Label>Limestone Rough Pavers</Label>
 		<color>(158,153,135)</color>
 		<RenderPrecedence>267</RenderPrecedence>
-		<Description>Rough stone paving. Limestone version. 
+		<Description>Rough stone pavers. Limestone version. 
 Beauty: 3.</Description>
 		<texturePath>Terrain/Surfaces/StoneRough</texturePath>
 		<researchPrerequisites><li>FloorArt</li></researchPrerequisites>
@@ -1819,10 +1819,10 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneRoughSlate</defName>
-		<Label>Rough Paving (Slate)</Label>
+		<Label>Slate Rough Pavers</Label>
 		<color>(70,70,70)</color>
 		<RenderPrecedence>267</RenderPrecedence>
-		<Description>Rough stone paving. Slate version. 
+		<Description>Rough stone pavers. Slate version. 
 Beauty: 3.</Description>
 		<texturePath>Terrain/Surfaces/StoneRough</texturePath>
 		<researchPrerequisites><li>FloorArt</li></researchPrerequisites>
@@ -1834,10 +1834,10 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneRoughMarble</defName>
-		<Label>Rough Paving (Marble)</Label>
+		<Label>Marble Rough Pavers</Label>
 		<color>(132,135,132)</color>
 		<RenderPrecedence>267</RenderPrecedence>
-		<Description>Rough stone paving. Marble version. 
+		<Description>Rough stone pavers. Marble version. 
 Beauty: 3.</Description>
 		<texturePath>Terrain/Surfaces/StoneRough</texturePath>
 		<researchPrerequisites><li>FloorArt</li></researchPrerequisites>
@@ -1851,10 +1851,10 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneRandomSandstone</defName>
-		<Label>Random Paving (Sandstone)</Label>
+		<Label>Sandstone Random Pavers</Label>
 		<color>(126,104,94)</color>
 		<RenderPrecedence>266</RenderPrecedence>
-		<Description>Stone paving with random square and rectangular slabs. Sandstone version. 
+		<Description>Stone pavers with a random mix of square and rectangular pieces. Sandstone version. 
 Beauty: 3.</Description>
 		<texturePath>Terrain/Surfaces/StoneRandom</texturePath>
 		<researchPrerequisites><li>FloorArtII</li></researchPrerequisites>
@@ -1866,10 +1866,10 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneRandomGranite</defName>
-		<Label>Random Paving (Granite)</Label>
+		<Label>Granite Random Pavers</Label>
 		<color>(105,95,97)</color>
 		<RenderPrecedence>266</RenderPrecedence>
-		<Description>Stone paving with random square and rectangular slabs. Granite version. 
+		<Description>Stone pavers with a random mix of square and rectangular pieces. Granite version. 
 Beauty: 3.</Description>
 		<texturePath>Terrain/Surfaces/StoneRandom</texturePath>
 		<researchPrerequisites><li>FloorArtII</li></researchPrerequisites>
@@ -1881,10 +1881,10 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneRandomLimestone</defName>
-		<Label>Random Paving (Limestone)</Label>
+		<Label>Limestone Random Pavers</Label>
 		<color>(158,153,135)</color>
 		<RenderPrecedence>266</RenderPrecedence>
-		<Description>Stone paving with random square and rectangular slabs. Limestone version. 
+		<Description>Stone pavers with a random mix of square and rectangular pieces. Limestone version. 
 Beauty: 3.</Description>
 		<texturePath>Terrain/Surfaces/StoneRandom</texturePath>
 		<researchPrerequisites><li>FloorArtII</li></researchPrerequisites>
@@ -1896,10 +1896,10 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneRandomSlate</defName>
-		<Label>Random Paving (Slate)</Label>
+		<Label>Slate Random Pavers</Label>
 		<color>(70,70,70)</color>
 		<RenderPrecedence>266</RenderPrecedence>
-		<Description>Stone paving with random square and rectangular slabs. Slate version. 
+		<Description>Stone pavers with a random mix of square and rectangular pieces. Slate version. 
 Beauty: 3.</Description>
 		<texturePath>Terrain/Surfaces/StoneRandom</texturePath>
 		<researchPrerequisites><li>FloorArtII</li></researchPrerequisites>
@@ -1911,10 +1911,10 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneRandomMarble</defName>
-		<Label>Random Paving (Marble)</Label>
+		<Label>Marble Random Pavers</Label>
 		<color>(132,135,132)</color>
 		<RenderPrecedence>266</RenderPrecedence>
-		<Description>Stone paving with random square and rectangular slabs. Marble version.
+		<Description>Stone pavers with a random mix of square and rectangular pieces. Marble version.
 Beauty: 3.</Description>
 		<texturePath>Terrain/Surfaces/StoneRandom</texturePath>
 		<researchPrerequisites><li>FloorArtII</li></researchPrerequisites>

--- a/Mods/Core_SK/Defs/ThingDefs/Weapons_Turrets_SK.xml
+++ b/Mods/Core_SK/Defs/ThingDefs/Weapons_Turrets_SK.xml
@@ -314,11 +314,11 @@
 	</ThingDef>
 	
 	
-<!-- ================ Sentry rocket launcher ============== -->
+<!-- ================ Sentry Rocket Launcher ============== -->
 
 	<ThingDef ParentName="BaseAutoTurretGun">
 		<defName>Gun_SentryRocketLauncher</defName>
-		<label>Sentry rocket launcher</label>
+		<label>Sentry Rocket Launcher</label>
     <graphicData>
 		<texPath>Things/Building/Security/EMPTurretGun_Top</texPath>
 		<graphicClass>Graphic_Single</graphicClass>
@@ -650,11 +650,11 @@
 	</ThingDef>
 
 
-<!-- ================ 20mm Oerlikon autocannon ============== -->
+<!-- ================ 20mm Oerlikon Autocannon ============== -->
 
   <ThingDef ParentName="BaseTurretGun">
 		<defName>Gun_Oerlikonautocannon</defName>
-		<label>20mm Oerlikon autocannon</label>
+		<label>20mm Oerlikon Autocannon</label>
     <graphicData>
 		<texPath>Things/Building/Security/AMTurretGun_Top</texPath>
 		<graphicClass>Graphic_Single</graphicClass>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Defences_SK.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Defences_SK.xml
@@ -372,7 +372,7 @@
 
   <ThingDef ParentName="BuildingBase">
     <defName>TrapDeadfall</defName>
-    <label>deadfall trap</label>
+    <label>Deadfall Trap</label>
     <thingClass>Building_TrapRearmable</thingClass>
     <graphicData>
       <texPath>Things/Building/Security/DeadfallArmed</texPath>
@@ -414,7 +414,7 @@
 
   <ThingDef ParentName="BuildingBase">
     <defName>TrapIEDBomb</defName>
-    <label>IED trap</label>
+    <label>IED Trap</label>
     <thingClass>Building_TrapExplosive</thingClass>
     <graphicData>
       <texPath>Things/Building/Security/IEDBomb</texPath>
@@ -462,7 +462,7 @@
   
   <ThingDef ParentName="BuildingBase">
     <defName>TrapIEDIncendiary</defName>
-    <label>IED incendiary trap</label>
+    <label>IED Incendiary Trap</label>
     <thingClass>Building_TrapExplosive</thingClass>
     <graphicData>
       <texPath>Things/Building/Security/IEDIncendiary</texPath>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Furniture_SK.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Furniture_SK.xml
@@ -505,7 +505,7 @@
   
   <ThingDef ParentName="HighQualityFurnitureBase">
     <defName>DoubleBed</defName>
-    <label>Double bed</label>
+    <label>Double Bed</label>
     <Description>A simple double-wide bed that fits two people.</Description>
     <ThingClass>Building_Bed</ThingClass>
     <graphicData>
@@ -1525,7 +1525,7 @@
   
   <ThingDef ParentName="TableBase">
     <defName>TableSmall</defName>
-    <label>Table (small)</label>
+    <label>Table (Small)</label>
     <thingClass>Feast.Building_Table</thingClass>
     <graphicData>
       <texPath>Things/Building/Furniture/SmallTable</texPath>
@@ -1711,7 +1711,7 @@
   <ThingDef ParentName="TableBase">
     <thingClass>Building</thingClass>
     <defName>GlassTableShort</defName>
-    <label>Glass Table</label>
+    <label>Table</label>
 	<description>Colonists will eat off of tables when a chair is facing it. This tiny glass table is suitable for 1.</description>
 	<graphicData>
 	<texPath>Things/Building/GlassTableShort</texPath>
@@ -1743,7 +1743,7 @@
   
   <ThingDef ParentName="FurnitureBase">
     <defName>Commode</defName>
-    <label>Commode</label>
+    <label>Dresser</label>
     <description>A place for colonist to store personal belongings. When placed with a bed it will increase comfort and rest effectiveness slightly.</description>
     <graphicData>
       <texPath>Things/Building/Furniture/Dresser</texPath>
@@ -3391,7 +3391,7 @@
   
   <ThingDef ParentName="BuildingBase">
     <defName>Lighting_PathLamp</defName>
-    <label>Path light</label>
+    <label>Path Light</label>
     <thingClass>SK.Building_PL</thingClass>
     <category>Building</category>
     <graphicData>
@@ -3905,7 +3905,7 @@
   
 	<ThingDef ParentName="BuildingBase">
 		<defName>FloorAddonA</defName>
-		<label>Zone marker</label>
+		<label>Zone Marker</label>
 		<thingClass>Building</thingClass>
 		<category>Building</category>
 		 <graphicData>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Misc_Pyre.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Misc_Pyre.xml
@@ -14,7 +14,7 @@
 
   <ThingDef ParentName="PyreBase">
     <defName>Pyre</defName>
-    <label>pyre</label>
+    <label>Pyre</label>
     <description>A big pile of wood. Can be lit to start a campfire party. Get your colonists even happier with some beers!</description>
     <thingClass>CampfireParty.Building_Pyre</thingClass>
     <category>Building</category>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Misc_SK.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Misc_SK.xml
@@ -561,7 +561,7 @@
   
       <ThingDef ParentName="BuildingBase">
     <defName>CookingTools</defName>
-    <label>Cooking tools</label>
+    <label>Cooking Tools</label>
     <graphicData>
       <texPath>Things/Building/Production/CookingTools</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -577,7 +577,7 @@
       <WorkToMake>2800</WorkToMake>
       <Flammability>1.0</Flammability>
     </statBases>
-    <description>Increases work speed. Needs to be placed near workbench. One workbench can be simultaneously linked to only two tool cabinets.</description>
+    <description>Increases work speed. Needs to be placed near a cooking workbench. One set of cooking tools can be simultaneously linked to only two cooking workbenches.</description>
     <size>(1,1)</size>
 		<stuffCategories>
 			<li>Metallic</li>
@@ -608,7 +608,7 @@
 
   <ThingDef ParentName="BuildingBase">
     <defName>FirefoamPopper</defName>
-    <label>Firefoam popper</label>
+    <label>Firefoam Popper</label>
     <thingClass>Building_FirefoamPopper</thingClass>
     <description>When touched by fire or triggered by hand, this pops and sprays a fire-extinguishing foam in a circular field around itself.</description>
     <graphicData>
@@ -1111,7 +1111,7 @@
   
   <ThingDef ParentName="BuildingBase">
     <defName>DermalRegenerator</defName>
-    <label>Dermal regenerator</label>
+    <label>Dermal Regenerator</label>
     <graphicData>
       <texPath>Things/Building/DermalRegenerator</texPath>
       <graphicClass>Graphic_Single</graphicClass>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
@@ -462,9 +462,9 @@
 
 <ThingDef ParentName="BenchBase">
 	<DefName>Canningstove</DefName>
-	<label>Electric Pressure Cooker</label>
+	<label>Electric Pressure Canner</label>
 	<ThingClass>Building_WorkTable_HeatPush</ThingClass>
-	<Description>A stove for canning foods, drying fruit, and making tofu. Requires power.</Description>
+	<Description>A specialized device for canning foods, drying fruit, and making tofu. Requires power.</Description>
 	<graphicData>
       <texPath>Things/Building/Production/Canningstove</texPath>
       <graphicClass>Graphic_Multi</graphicClass>
@@ -5208,7 +5208,7 @@
   
   <ThingDef ParentName="BuildingBase">
     <defName>PremitiveHydroponic</defName>
-    <label>Saturated soil</label>
+    <label>Saturated Soil</label>
     <thingClass>HydroponicRoom.Building_PlantGrowerLinked</thingClass>
     <graphicData>
       <ShaderType>CutoutComplex</ShaderType>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Security_SK.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Security_SK.xml
@@ -62,7 +62,7 @@
   <!--=============== Improvised turret ===============-->
    <ThingDef ParentName="TurretBase">
     <defName>TurretGun</defName>
-	<label>Sentry light turret</label>
+	<label>Sentry Light Turret</label>
     <graphicData>
       <texPath>Things/Building/Security/TurretImprovised</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -110,7 +110,7 @@
   
    <ThingDef ParentName="TurretBase">
     <defName>Turret_Blaster</defName>
-    <label>Sentry blaster turret</label>
+    <label>Sentry Blaster Turret</label>
     <graphicData>
       <texPath>Things/Building/Turrets/MachineGunBase</texPath>
     </graphicData>
@@ -150,7 +150,7 @@
  
    <ThingDef ParentName="TurretBase">
     <defName>Turret_Laserbeam</defName>
-    <label>Sentry laserbeam turret</label>
+    <label>Sentry Laserbeam Turret</label>
     <graphicData>
       <texPath>Things/Building/Security/PrecisionTurretBase</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -199,7 +199,7 @@
 
   <ThingDef ParentName="TurretBase">
     <defName>Turret_Heavy</defName>
-    <label>Sentry heavy turret</label>
+    <label>Sentry Heavy Turret</label>
     <graphicData>
       <texPath>Things/Building/Turrets/MachineGunBase</texPath>
     </graphicData>
@@ -238,7 +238,7 @@
   
   <ThingDef ParentName="TurretBase">
 		<defName>NavalGunTurretGun</defName>
-		<label>Sentry naval turret</label>
+		<label>Sentry Naval Turret</label>
 		<graphicData>
 		<texPath>Things/Building/Security/NavalGunTurretGun</texPath>
     		<graphicClass>Graphic_Single</graphicClass>
@@ -285,7 +285,7 @@
   
 	<ThingDef ParentName="TurretBase">
 	<defName>Turret_SentryRocketLauncher</defName>
-	<label>Sentry rocket launcher</label>
+	<label>Sentry Rocket Launcher</label>
     <graphicData>
 		<texPath>Things/Building/Security/MachineGunBase</texPath>
     <graphicClass>Graphic_Single</graphicClass>
@@ -334,7 +334,7 @@
 	
   <ThingDef Name="MortarBase" ParentName="BuildingBase" Abstract="True">
 	<defName>Turret_MortarBombCR</defName>
-	<label>81mm artillery mortar</label>
+	<label>81mm Artillery Mortar</label>
     <description>A mortar that launches explosive shells. Must be manned.</description>
     <thingClass>Combat_Realism.Building_TurretGunCR</thingClass>
     <graphicData>
@@ -592,7 +592,7 @@
   
   <ThingDef ParentName="TurretMannedBase">
     <defName>Turret_ChainGun</defName>
-    <label>30mm GSh-30 cannon</label>
+    <label>30mm GSh-30 Cannon</label>
     <graphicData>
     <texPath>Things/Building/Security/TurretGun_three</texPath>
 	<graphicClass>Graphic_Single</graphicClass>
@@ -672,7 +672,7 @@
 
   <ThingDef ParentName="TurretMannedBase">
 		<defName>Turret_Oerlikonautocannon</defName>
-		<label>20mm Oerlikon autocannon</label>
+		<label>20mm Oerlikon Autocannon</label>
 		<graphicData>
 			<texPath>Things/Building/Security/AMTurretGun</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -711,7 +711,7 @@
 
   <ThingDef ParentName="TurretMannedBase">
     <defName>Turret_VulcanCannon</defName>
-    <label>20mm Vulcan cannon</label>
+    <label>20mm Vulcan Cannon</label>
     <graphicData>
     <texPath>Things/Building/Security/VulcanCannon</texPath>
     <graphicClass>Graphic_Single</graphicClass>
@@ -830,7 +830,7 @@
   
   <ThingDef ParentName="TurretMannedBase">
     <defName>Turret_Flak</defName>
-    <label>90mm Flak turret</label>
+    <label>90mm Flak Turret</label>
     <graphicData>
       <texPath>Things/Building/Turrets/FlakTurret_Base</texPath>
     </graphicData>
@@ -864,7 +864,7 @@
 
   <ThingDef ParentName="TurretMannedBase">
 	<defName>Turret_Cannon</defName>
-	<label>120mm tank cannon turret</label>
+	<label>120mm Tank Cannon Turret</label>
 	<graphicData>
 		<texPath>Things/Building/Security/TurretGun_Cannon</texPath>
 		<graphicClass>Graphic_Single</graphicClass>
@@ -908,7 +908,7 @@
 
   <ThingDef ParentName="TurretMannedBase">
 		<defName>HowitzerTurretGun</defName>
-		<label>155mm Howitzer Cannon turret</label>
+		<label>155mm Howitzer Cannon Turret</label>
     <graphicData>
 		<texPath>Things/Building/Security/SpotlightBase</texPath>
     <graphicClass>Graphic_Single</graphicClass>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Structure_SK.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Structure_SK.xml
@@ -83,7 +83,7 @@
 
   <ThingDef ParentName="DoorBase">
     <defName>Door</defName>
-    <label>door</label>
+    <label>Door</label>
     <description>Divides rooms. Must be manually opened and closed, which slows people down.</description>
     <statBases>
 	  <MaxHitPoints>200</MaxHitPoints>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Items_Turrets.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Items_Turrets.xml
@@ -59,7 +59,7 @@
   
   <ThingDef ParentName="MinifiedTurretBase">
     <defName>MinifiedTurretGun</defName>
-    <label>Sentry blaster turret</label>
+    <label>Sentry Blaster Turret</label>
     <statBases>
 			<Weight>16</Weight>
 			<Bulk>20</Bulk>
@@ -68,7 +68,7 @@
   
   <ThingDef ParentName="MinifiedTurretBase">
     <defName>MinifiedTurret_Blaster</defName>
-    <label>Sentry blaster turret</label>
+    <label>Sentry Blaster Turret</label>
     <statBases>
 			<Weight>20</Weight>
 			<Bulk>25</Bulk>
@@ -77,7 +77,7 @@
   
   <ThingDef ParentName="MinifiedTurretBase">
     <defName>MinifiedTurret_Laserbeam</defName>
-    <label>Sentry laserbeam turret</label>
+    <label>Sentry Laserbeam Turret</label>
     <statBases>
 			<Weight>20</Weight>
 			<Bulk>25</Bulk>
@@ -87,7 +87,7 @@
   
   <ThingDef ParentName="MinifiedTurretBase">
     <defName>MinifiedTurret_Heavy</defName>
-    <label>Sentry heavy turret</label>
+    <label>Sentry Heavy Turret</label>
     <statBases>
 			<Weight>80</Weight>
 			<Bulk>100</Bulk>
@@ -96,7 +96,7 @@
   
   <ThingDef ParentName="MinifiedTurretBase">
     <defName>MinifiedTurret_NavalGunTurretGun</defName>
-    <label>Sentry naval turret</label>
+    <label>Sentry Naval Turret</label>
     <statBases>
 			<Weight>1200</Weight>
 			<Bulk>1100</Bulk>
@@ -106,7 +106,7 @@
   
   <ThingDef ParentName="MinifiedTurretBase">
     <defName>MinifiedTurret_M240B</defName>
-    <label>M240B machine gun</label>
+    <label>M240B Machine Gun</label>
     <statBases>
 			<Weight>16.5</Weight>
 			<Bulk>20</Bulk>
@@ -115,7 +115,7 @@
   
   <ThingDef ParentName="MinifiedTurretBase">
     <defName>MinifiedTurret_FFautocannon</defName>
-    <label>M240B machine gun</label>
+    <label>M240B Machine Gun</label>
     <statBases>
 			<Weight>76.5</Weight>
 			<Bulk>80</Bulk>
@@ -152,7 +152,7 @@
   
   <ThingDef ParentName="MinifiedTurretBase">
     <defName>MinifiedTurret_Avenger</defName>
-    <label>30mm Avenger cannon</label>
+    <label>30mm Avenger Cannon</label>
     <statBases>
 		  <Weight>59</Weight>
 		  <Bulk>61</Bulk>
@@ -161,7 +161,7 @@
   
   <ThingDef ParentName="MinifiedTurretBase">
     <defName>MinifiedTurret_VulcanCannon</defName>
-    <label>20mm Vulcan cannon</label>
+    <label>20mm Vulcan Cannon</label>
 	<statBases>
 		  <Weight>120</Weight>
 		  <Bulk>100</Bulk>
@@ -171,7 +171,7 @@
   
   <ThingDef ParentName="MinifiedTurretBase">
     <defName>MinifiedTurret_Flak</defName>
-    <label>90mm flak turret</label>
+    <label>90mm Flak Turret</label>
     <statBases>
 			<Weight>1000</Weight>
 			<Bulk>1000</Bulk>
@@ -180,7 +180,7 @@
   
   <ThingDef ParentName="MinifiedTurretBase">
     <defName>MinifiedTurret_SentryRocketLauncher</defName>
-    <label>Sentry rocket launcher</label>
+    <label>Sentry Rocket Launcher</label>
     <statBases>
 			<Weight>150</Weight>
 			<Bulk>200</Bulk>
@@ -189,7 +189,7 @@
   
   <ThingDef ParentName="MinifiedTurretBase">
     <defName>MinifiedTurret_Cannon</defName>
-    <label>120mm tank cannon turret</label>
+    <label>120mm Tank Cannon Turret</label>
     <statBases>
 			<Weight>1600</Weight>
 			<Bulk>1200</Bulk>

--- a/Mods/Core_SK/Defs/ThingDefs_Items/Items_Ammo_SK.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Items/Items_Ammo_SK.xml
@@ -593,7 +593,7 @@
 
 <ThingDef ParentName="CrateBase">
 <defName>LaserTurret_Crate</defName>
-<label>Senter Laserbeam Turret Crate</label>
+<label>Sentry Laserbeam Turret Crate</label>
 <description>Use this to build a Sentry Laserbeam Turret, a type of unmanned automatic turret. It requires 2,500 W to function and does not need ammo.</description>
     <graphicData>
 <texPath>Things/Item/Resource/WeaponCrate</texPath>

--- a/Mods/Core_SK/Defs/ThingDefs_Items/Items_Ammo_SK.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Items/Items_Ammo_SK.xml
@@ -59,7 +59,7 @@
 
 <ThingDef ParentName="CrateBase">
 <defName>Oerlikonautocannon_Crate</defName>
-<label>20mm Oerlikon autocannon</label>
+<label>20mm Oerlikon Autocannon</label>
 <description>Use this to build an Anti-Materiel Turret, a type of stationary manned turret. It uses .50calx6 AM Turret Rounds for ammo.</description>
     <graphicData>  
 <texPath>Things/Item/Resource/WeaponCrate</texPath>
@@ -86,7 +86,7 @@
 
 <ThingDef ParentName="CrateBase">
 <defName>SentryBlasterTurret_Crate</defName>
-<label>Sentry blaster crate</label>
+<label>Sentry Blaster Crate</label>
 <description>Use this to build a sentry blaster turret crate, a type of automatic turrets. Requires power to function but does not need ammo.</description>
     <graphicData> 
 <texPath>Things/Item/Resource/WeaponCrate</texPath>
@@ -113,7 +113,7 @@
 
 <ThingDef ParentName="CrateBase">
 <defName>SentryRocketLauncher_Crate</defName>
-<label>Sentry rocket launcher Crate</label>
+<label>Sentry Rocket Launcher Crate</label>
 <description>Use this to build an Sentry rocket launcher, a type of stationary unmanned turret.</description>
     <graphicData> 
 <texPath>Things/Item/Resource/WeaponCrate</texPath>
@@ -274,8 +274,8 @@
 
 <ThingDef ParentName="CrateBase">
 <defName>Chain_Crate</defName>
-<label>30mm GSh-30 cannon vrate</label>
-<description>Use this to build a 30mm GSh-30 cannon, a type of stationary manned turret. It uses 35mmx3 Autocannon Shells for ammo.</description>
+<label>30mm GSh-30 Cannon Crate</label>
+<description>Use this to build a 30mm GSh-30 Cannon, a type of stationary manned turret. It uses 35mmx3 Autocannon Shells for ammo.</description>
     <graphicData>   
 <texPath>Things/Item/Resource/WeaponCrate</texPath>
 <graphicClass>Graphic_Single</graphicClass>
@@ -301,8 +301,8 @@
 
 <ThingDef ParentName="CrateBase">
 <defName>NavalGunTurret_Crate</defName>
-<label>Sentry naval crate</label>
-<description>Use this to build Sentry naval turret, a type of stationary unmanned turret.</description>
+<label>Sentry Naval Turret Crate</label>
+<description>Use this to build Sentry Naval Turret, a type of stationary unmanned turret.</description>
 <graphicData>
 <texPath>Things/Item/Resource/WeaponCrate</texPath>
 <graphicClass>Graphic_Single</graphicClass>  
@@ -379,8 +379,8 @@
 
 <ThingDef ParentName="CrateBase">
 <defName>AGSturret_Crate</defName>
-<label>30mm AGS-17 crate</label>
-<description>Use this to build a AGS-17, a type of stationary manned turret. It uses 30mmx6 GL Turret Grenades for ammo.</description>
+<label>30mm AGS-17 Crate</label>
+<description>Use this to build an AGS-17, a type of stationary manned turret. It uses 30mmx6 GL Turret Grenades for ammo.</description>
     <graphicData> 
 <texPath>Things/Item/Resource/WeaponCrate</texPath>
 <graphicClass>Graphic_Single</graphicClass>
@@ -405,7 +405,7 @@
 
 <ThingDef ParentName="CrateBase">
 <defName>AGCturret_Crate</defName>
-<label>30mm AGS-30 crate</label>
+<label>30mm AGS-30 Crate</label>
 <description>Use this to build AGS-30, a type of stationary manned turret. It uses 30mmx6 GL Turret Grenades for ammo.</description>
     <graphicData> 
 <texPath>Things/Item/Resource/WeaponCrate</texPath>
@@ -431,8 +431,8 @@
 
 <ThingDef ParentName="CrateBase">
 <defName>FlakTurret_Crate</defName>
-<label>90mm Flak turret crate</label>
-<description>Use this to build a 90mm Flak turret a type of stationary manned turret. It uses 120mm Cannon Shells for ammo.</description>
+<label>90mm Flak Turret Crate</label>
+<description>Use this to build a 90mm Flak Turret a type of stationary manned turret. It uses 120mm Cannon Shells for ammo.</description>
     <graphicData>
 <texPath>Things/Item/Resource/WeaponCrate</texPath>
 <graphicClass>Graphic_Single</graphicClass>
@@ -458,7 +458,7 @@
 
 <ThingDef ParentName="CrateBase">
 <defName>CannonTurret_Crate</defName>
-<label>120mm Tank cannon crate</label>
+<label>120mm Tank Cannon Crate</label>
 <description>Use this to build a 120mm Tank Cannon, a type of stationary manned turret. It uses 120mm Cannon Shells for ammo.</description>
     <graphicData>
 <texPath>Things/Item/Resource/WeaponCrate</texPath>
@@ -512,7 +512,7 @@
 
 <ThingDef ParentName="CrateBase">
 <defName>MinigunTurret_Crate</defName>
-<label>M134 Minigun crate</label>
+<label>M134 Minigun Crate</label>
 <description>Use this to build a 20mm Vulcan Cannon, a type of stationary manned turret. Requires 800 W to function and it uses 20mmx20 Vulcan Bullets for ammo.</description>
     <graphicData>
 <texPath>Things/Item/Resource/WeaponCrate</texPath>
@@ -539,7 +539,7 @@
 
 <ThingDef ParentName="CrateBase">
 <defName>KPV_Crate</defName>
-<label>14.5mm KPV MG crate</label>
+<label>14.5mm KPV MG Crate</label>
 <description>Use this to build a 14.5mm KPV MG, a type of stationary manned turret. Requires 800 W to function and it uses 20mmx20 Vulcan Bullets for ammo.</description>
     <graphicData>
 <texPath>Things/Item/Resource/WeaponCrate</texPath>
@@ -593,8 +593,8 @@
 
 <ThingDef ParentName="CrateBase">
 <defName>LaserTurret_Crate</defName>
-<label>Laser Turret Crate</label>
-<description>Use this to build a Laser Turret, a type of unmanned automatic turret. It requires 2,500 W to function and does not need ammo.</description>
+<label>Senter Laserbeam Turret Crate</label>
+<description>Use this to build a Sentry Laserbeam Turret, a type of unmanned automatic turret. It requires 2,500 W to function and does not need ammo.</description>
     <graphicData>
 <texPath>Things/Item/Resource/WeaponCrate</texPath>
 <graphicClass>Graphic_Single</graphicClass>
@@ -620,8 +620,8 @@
 
 <ThingDef ParentName="CrateBase">
 <defName>SentryTurret_Crate</defName>
-<label>Sentry  light crate</label>
-<description>Use this to build an Automated Sentry light turret, a type of stationary automatic turret. It requires 800 W to function and does not need ammo.</description>
+<label>Sentry Light Turret Crate</label>
+<description>Use this to build an automated Sentry Light Turret, a type of stationary automatic turret. It requires 800 W to function and does not need ammo.</description>
     <graphicData>
 <texPath>Things/Item/Resource/WeaponCrate</texPath>
 <graphicClass>Graphic_Single</graphicClass>
@@ -647,8 +647,8 @@
 
 <ThingDef ParentName="CrateBase">
 <defName>HeavyTurret_Crate</defName>
-<label>Sentry heavy crate</label>
-<description>Use this to build a Laser Turret, a type of unmanned automatic turret.</description>
+<label>Sentry Heavy Turret Crate</label>
+<description>Use this to build a Sentry Heavy Turret, a type of unmanned automatic turret.</description>
     <graphicData>
 <texPath>Things/Item/Resource/WeaponCrate</texPath>
 <graphicClass>Graphic_Single</graphicClass>

--- a/Mods/Core_SK/Defs/ThingDefs_Items/Items_Resource_SK.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Items/Items_Resource_SK.xml
@@ -3467,7 +3467,7 @@
   <ThingDef ParentName="ResourceBase">
     <defName>Rubber</defName>
     <label>Rubber</label>
-    <description>Rubber is useful for a variety of things such as duct pipes, pumps or as a building material supplement/additive.</description>
+    <description>Rubber is useful for a variety of things such as Duct Pipes, pumps or as a building material supplement/additive.</description>
     <graphicData>
     <texPath>Things/Item/Resource/Rubber</texPath>
     <Color>(255,255,255)</Color>

--- a/Mods/FishIndustry_SK/Defs/ThingDefs/Building_AquacultureBasin.xml
+++ b/Mods/FishIndustry_SK/Defs/ThingDefs/Building_AquacultureBasin.xml
@@ -16,7 +16,7 @@
 
   <ThingDef ParentName="BuildingBase">
     <defName>AquacultureBasin</defName>
-    <Label>aquaculture basin</Label>
+    <Label>Aquaculture Basin</Label>
     <Description>A basin designed to breed fishes. Water quality is auto-regulated. You need to provide an external temperature regulation and some food in attached hopper to feed the bred fishes.</Description>
     <thingClass>FishIndustry.Building_AquacultureBasin</thingClass>
     <TickerType>Normal</TickerType>

--- a/Mods/FishIndustry_SK/Defs/ThingDefs/Building_AquacultureHopper.xml
+++ b/Mods/FishIndustry_SK/Defs/ThingDefs/Building_AquacultureHopper.xml
@@ -4,7 +4,7 @@
 
   <ThingDef ParentName="BuildingBase">
     <defName>AquacultureHopper</defName>
-    <label>aquaculture hopper</label>
+    <label>Aquaculture Hopper</label>
     <description>Holds food to feed bred species in aquaculture basins. This hopper is refrigerated and food within will not spoil if powered.</description>
     <thingClass>FishIndustry.Building_AquacultureHopper</thingClass>
     <placeWorkers>

--- a/Mods/Hospitality/Defs/ThingDefs/Buildings_Furniture.xml
+++ b/Mods/Hospitality/Defs/ThingDefs/Buildings_Furniture.xml
@@ -84,7 +84,7 @@
   
   <ThingDef ParentName="FurnitureBase">
     <defName>GuestBed</defName>
-    <label>guest bed</label>
+    <label>Guest Bed</label>
     <Description>A place for guests to sleep during their stay.</Description>
     <ThingClass>Hospitality.Building_GuestBed</ThingClass>
     <graphicData>

--- a/Mods/Hospitality/Languages/English/DefInjected/ThingDef/Buildings_Furniture.xml
+++ b/Mods/Hospitality/Languages/English/DefInjected/ThingDef/Buildings_Furniture.xml
@@ -2,7 +2,7 @@
 <!--suppress ALL -->
 <LanguageData>
 	
-	<GuestBed.label>guest bed</GuestBed.label>
+	<GuestBed.label>Guest Bed</GuestBed.label>
 	<GuestBed.Description>A place for guests to sleep during their stay.</GuestBed.Description>
 
 </LanguageData>

--- a/Mods/LDAreaRugs/Defs/ThingDefs/LD-Tables.xml
+++ b/Mods/LDAreaRugs/Defs/ThingDefs/LD-Tables.xml
@@ -68,7 +68,7 @@
 
    <ThingDef ParentName="BuildingBase">
 	    <DefName>TableRugMaking</DefName>
-	    <label>Rug Making table</label>
+	    <label>Rug Making Table</label>
 	    <ThingClass>Building_WorkTable</ThingClass>
 	    <Description>A table with all the tools needed to make rugs out of various fabrics.</Description>
 	    <graphicData>

--- a/Mods/LT_RedistHeat/Defs/ResearchProjectDefs/ResearchProjects.xml
+++ b/Mods/LT_RedistHeat/Defs/ResearchProjectDefs/ResearchProjects.xml
@@ -3,8 +3,8 @@
 
 	<ResearchProjectDef>
 	    <defName>RedistHeat_AirCirculation</defName>
-	    <label>Air circulation</label>
-	    <description>Allows you to build active vents and smart duct outlets.</description>
+	    <label>Air Circulation</label>
+	    <description>Allows you to build Active Vents and Smart Duct outlets.</description>
 	    <totalCost>500</totalCost>
 		<prerequisites>
 			<li>ConstructionII</li>
@@ -14,7 +14,7 @@
 
 	<ResearchProjectDef>
 	    <defName>RedistHeat_TemperatureControl</defName>
-	    <label>Temperature control</label>
+	    <label>Temperature Control</label>
 	    <description>Allows you to build industrial temperature controller buildings.</description>
 	    <totalCost>800</totalCost>
 		<prerequisites>

--- a/Mods/LT_RedistHeat/Defs/ThingDefs/Buildings_Duct.xml
+++ b/Mods/LT_RedistHeat/Defs/ThingDefs/Buildings_Duct.xml
@@ -87,7 +87,7 @@
 
     <ThingDef ParentName="PipeBase">
         <defName>RedistHeat_DuctPipeUpper</defName>
-        <label>Duct pipe (upper)</label>
+        <label>Duct Pipe (upper)</label>
         <graphicData>
             <texPath>Things/Building/Linked/DuctPipeUpper</texPath>
             <linkFlags>
@@ -105,7 +105,7 @@
 
     <ThingDef ParentName="PipeBase">
         <defName>RedistHeat_DuctPipeLower</defName>
-        <label>Duct pipe (lower)</label>
+        <label>Duct Pipe (lower)</label>
         <graphicData>
             <texPath>Things/Building/Linked/DuctPipeLower</texPath>
             <linkFlags>
@@ -162,7 +162,7 @@
     <ThingDef ParentName="DuctBuildingBaseDuckwork">
         <defName>RedistHeat_DuctOutlet</defName>
         <thingClass>RedistHeat.Building_DuctComp</thingClass>
-        <label>Duct outlet</label>
+        <label>Duct Outlet</label>
         <description>A duct building that pulls air from network.</description>
         <graphicData>
             <graphicClass>RedistHeat.Graphic_MultiDXT5</graphicClass>
@@ -203,7 +203,7 @@
     <ThingDef ParentName="DuctBuildingBaseDuckwork">
         <defName>RedistHeat_SmartDuctOutlet</defName>
         <thingClass>RedistHeat.Building_SmartDuctOutlet</thingClass>
-        <label>Smart duct outlet</label>
+        <label>Smart Duct Outlet</label>
         <description>A duct building that pulls air from network. It can automatically open or close itself to control airflow.</description>
         <graphicData>
             <texPath>Things/Building/AirNet/SmartDuctOutlet</texPath>
@@ -287,7 +287,7 @@
     <ThingDef ParentName="DuctCompBase">
         <defName>RedistHeat_DuctCooler</defName>
         <thingClass>RedistHeat.Building_DuctCooler</thingClass>
-        <label>Duct cooler</label>
+        <label>Duct Cooler</label>
         <description>A duct building that cools air within its network. Generates a lot of heat.</description>
         <graphicData>
             <graphicClass>RedistHeat.Graphic_SingleDXT5</graphicClass>

--- a/Mods/LT_RedistHeat/Defs/ThingDefs/Buildings_TempController.xml
+++ b/Mods/LT_RedistHeat/Defs/ThingDefs/Buildings_TempController.xml
@@ -52,7 +52,7 @@
 
     <ThingDef ParentName="BuildingBase">
         <defName>Heater</defName>
-        <label>Small heater</label>
+        <label>Small Heater</label>
         <thingClass>RedistHeat.Building_Heater</thingClass>
         <graphicData>
             <texPath>Things/Building/Misc/TempControl/Heater</texPath>
@@ -113,7 +113,7 @@
 
     <ThingDef ParentName="BuildingBase">
         <defName>Cooler</defName>
-        <label>Medium cooler</label>
+        <label>Medium Cooler</label>
         <thingClass>RedistHeat.Building_Cooler</thingClass>
         <graphicData>
             <texPath>Things/Building/Misc/TempControl/Cooler</texPath>
@@ -172,7 +172,7 @@
 
     <ThingDef ParentName="BuildingBase">
         <defName>RH_SmallCooler</defName>
-        <label>Small cooler</label>
+        <label>Small Cooler</label>
         <description>An electrical device that fits into a wall and pushes cold air into a room. Its exhaust port generates a lot of heat. Can be used to cool down rooms or to create a walk-in freezer.</description>
         <thingClass>Building_Cooler</thingClass>
         <graphicData>
@@ -238,7 +238,7 @@
     <ThingDef ParentName="BuildingBase">
         <defName>RH_MediumHeater</defName>
         <thingClass>RedistHeat.Building_MediumHeater</thingClass>
-        <label>Medium heater</label>
+        <label>Medium Heater</label>
         <description>A wall mounted heater which is more efficient at heating large rooms and bases. It can automatically turn itself on or off to reach a specific target temperature.</description>
         <graphicData>
             <texPath>Things/Building/Heater/MediumHeater</texPath>
@@ -336,7 +336,7 @@
     <ThingDef ParentName="BuildingBase">
         <defName>RedistHeat_IndustrialHeater</defName>
         <thingClass>RedistHeat.Building_IndustrialHeater</thingClass>
-        <label>Industrial heater</label>
+        <label>Industrial Heater</label>
         <description>A massive industrial heater. It can efficiently heat large rooms and bases. It can automatically turn itself on or off to reach a specific target temperature.</description>
         <graphicData>
             <texPath>Things/Building/Heater/SuperHeater</texPath>
@@ -406,7 +406,7 @@
     <ThingDef ParentName="BuildingBase">
         <defName>RedistHeat_IndustrialCooler</defName>
         <thingClass>RedistHeat.Building_IndustrialCooler</thingClass>
-        <label>Industrial cooler</label>
+        <label>Industrial Cooler</label>
         <description>A massive electrical device that pushes cold air into a room. It needs at least one external exhaust port.</description>
         <graphicData>
             <texPath>Things/Building/Cooler/IndustrialCooler</texPath>
@@ -471,7 +471,7 @@
     <ThingDef ParentName="BuildingBase">
         <defName>RedistHeat_ExhaustPort</defName>
         <thingClass>RedistHeat.Building_ExhaustPort</thingClass>
-        <label>Exhaust port</label>
+        <label>Exhaust Port</label>
         <description>An electrical device that works as a exhaust port for a industrial cooler. Generates a lot of heat.</description>
         <graphicData>
             <texPath>Things/Building/Cooler/ExhaustPort</texPath>

--- a/Mods/LT_RedistHeat/Defs/ThingDefs/Buildings_Vent.xml
+++ b/Mods/LT_RedistHeat/Defs/ThingDefs/Buildings_Vent.xml
@@ -107,7 +107,7 @@
 
     <ThingDef ParentName="VentBase">
         <defName>RedistHeat_ActiveVent</defName>
-        <label>Active vent</label>
+        <label>Active Vent</label>
         <description>A simple vent for equalizing the temperature between two rooms without allowing people to walk between them. Orange colored side must be facing towards a room that that you want to control.</description>
         <thingClass>RedistHeat.Building_ActiveVent</thingClass>
         <graphicData>

--- a/Mods/Miscellaneous_Robots/Defs/ThingDefs/AIRobot_Buildings_RechargeStation.xml
+++ b/Mods/Miscellaneous_Robots/Defs/ThingDefs/AIRobot_Buildings_RechargeStation.xml
@@ -46,7 +46,7 @@
 
 	<ThingDef Class="AIRobot.ThingDef_AIRobot_Building_RechargeStation" ParentName="AIRobotRechargeStationBase">
 		<defName>AIRobot_RechargeStation_Hauler</defName>
-		<label>Hauler Base Station</label>
+		<label>HaulerBot Base Station</label>
 		<description>This station comes equipped with a specialized robot.</description>
 		<graphicData>
 			<texPath>Things/Building/AIRobot_RechargeStation/AIRobotRechargeStation_HBot</texPath>
@@ -85,7 +85,7 @@
 
 	<ThingDef Class="AIRobot.ThingDef_AIRobot_Building_RechargeStation" ParentName="AIRobotRechargeStationBase">
 		<defName>AIRobot_RechargeStation_Cleaner</defName>
-		<label>Cleaner Base Station</label>
+		<label>CleanerBot Base Station</label>
 		<description>This station comes equipped with a specialized robot.</description>
 		<graphicData>
 			<texPath>Things/Building/AIRobot_RechargeStation/AIRobotRechargeStation_CBot</texPath>

--- a/Mods/Miscellaneous_TrainingFacility/Defs/ThingDefs/Archery_Buildings.xml
+++ b/Mods/Miscellaneous_TrainingFacility/Defs/ThingDefs/Archery_Buildings.xml
@@ -16,7 +16,7 @@
 
 	<ThingDef ParentName="BuildingBase">
 		<defName>ArcheryTarget</defName>
-		<label>Archery target</label>
+		<label>Archery Target</label>
 		<description>The bow is an ancient hunting weapon that is nowadays mostly used for fun. It's relaxing and trains hand-eye coordination.</description>
 		<graphicData>
 			<texPath>Things/Building/Archery/ArcheryStand</texPath>

--- a/Mods/Miscellaneous_TrainingFacility/Defs/ThingDefs/TrainingFacility_Buildings.xml
+++ b/Mods/Miscellaneous_TrainingFacility/Defs/ThingDefs/TrainingFacility_Buildings.xml
@@ -4,7 +4,7 @@
 	<ThingDef ParentName="BuildingBase">
 		<defName>ShootingRangeTarget</defName>
 		<thingClass>TrainingFacility.Building_ShootingRange</thingClass>
-		<label>shooting target</label>
+		<label>Shooting Target</label>
 		<description>The shooting range is a place where you can train your hand-eye coordination.</description>
 		<graphicData>
 			<texPath>Things/Building/TrainingFacility/ShootingRangeTarget</texPath>
@@ -51,7 +51,7 @@
 	<ThingDef ParentName="BuildingBase">
 		<defName>MartialArtsTarget</defName>
 		<thingClass>TrainingFacility.Building_MartialArtsTarget</thingClass>
-		<label>martial arts target</label>
+		<label>Martial Arts Target</label>
 		<description>The martial arts dummy is a place where you can train your martial arts, with or without a weapon.</description>
 		<graphicData>
 			<texPath>Things/Building/TrainingFacility/MartialArtsTarget</texPath>

--- a/Mods/Miscellaneous_TrainingFacility/Languages/English/DefInjected/ThingDef/Archery.xml
+++ b/Mods/Miscellaneous_TrainingFacility/Languages/English/DefInjected/ThingDef/Archery.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <LanguageData>
 
-	<ArcheryTarget.label>archery target</ArcheryTarget.label>
+	<ArcheryTarget.label>Archery Target</ArcheryTarget.label>
 	<ArcheryTarget.description>The bow is an ancient hunting weapon that is nowadays mostly used for fun. It's relaxing and trains hand-eye coordination.</ArcheryTarget.description>
 	
 

--- a/Mods/Miscellaneous_TrainingFacility/Languages/English/DefInjected/ThingDef/TrainingFacility_Buildings.xml
+++ b/Mods/Miscellaneous_TrainingFacility/Languages/English/DefInjected/ThingDef/TrainingFacility_Buildings.xml
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <LanguageData>
 
-	<ShootingRangeTarget.label>shooting target</ShootingRangeTarget.label>
+	<ShootingRangeTarget.label>Shooting Target</ShootingRangeTarget.label>
 	<ShootingRangeTarget.description>The shooting range is a place where you can train your hand-eye coordination.</ShootingRangeTarget.description>
 	
-	<MartialArtsTarget.label>martial arts target</MartialArtsTarget.label>
+	<MartialArtsTarget.label>Martial Arts Target</MartialArtsTarget.label>
 	<MartialArtsTarget.description>The martial arts dummy is a place where you can train your martial arts, with or without a weapon.</MartialArtsTarget.description>
 
 </LanguageData>

--- a/Mods/PowerSwitch/Languages/English/DefInjected/ThingDef/Buildings_Power_PowerSwitch_Invisible.xml
+++ b/Mods/PowerSwitch/Languages/English/DefInjected/ThingDef/Buildings_Power_PowerSwitch_Invisible.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <LanguageData>
 	
-	<PowerConduitInvisible.label>power conduit</PowerConduitInvisible.label>
+	<PowerConduitInvisible.label>Hidden Power Conduit</PowerConduitInvisible.label>
 	<PowerConduitInvisible.description>A set of electrical cables for moving power around. These are hidden.</PowerConduitInvisible.description>
 	
 </LanguageData>

--- a/Mods/RT Fuse_SK/Defs/ResearchProjectDefs/ResearchProject_RTBasicFuses.xml
+++ b/Mods/RT Fuse_SK/Defs/ResearchProjectDefs/ResearchProject_RTBasicFuses.xml
@@ -4,7 +4,7 @@
 	<ResearchProjectDef>
 		<defName>ResearchProject_RTBasicFuses</defName>
 		<label>basic fuses</label>
-		<description>Allows building makeshift fuses; can be placed anywhere on a power network with batteries. Each one is enough to safely dissipate up to 3000 Wd (three standard batteries) discharge, but will require repairs if tripped.</description>
+		<description>Allows building Makeshift Fuses; can be placed anywhere on a power network with batteries. Each one is enough to safely dissipate up to 3000 Wd (three standard batteries) discharge, but will require repairs if tripped.</description>
 		<totalCost>500</totalCost>
 	</ResearchProjectDef>
 

--- a/Mods/RT Fuse_SK/Defs/ThingDefs/Building_RTCircuitBreaker.xml
+++ b/Mods/RT Fuse_SK/Defs/ThingDefs/Building_RTCircuitBreaker.xml
@@ -3,7 +3,7 @@
 
 	<ThingDef>
 		<defName>Building_RTCircuitBreaker</defName>
-		<label>circuit breaker</label>
+		<label>Circuit Breaker</label>
 		<description>A set of automatic circuit breakers. Handles up to 3000 Wd discharge, will flick off if tripped.</description>
 		<designationCategory>Power</designationCategory>
 

--- a/Mods/RT Fuse_SK/Languages/English/DefInjected/ResearchProjectDefs/ResearchProject_RTBasicFuses.xml
+++ b/Mods/RT Fuse_SK/Languages/English/DefInjected/ResearchProjectDefs/ResearchProject_RTBasicFuses.xml
@@ -2,6 +2,6 @@
 <LanguageData>
 
 	<ResearchProject_RTBasicFuses.label>basic fuses</ResearchProject_RTBasicFuses.label>
-	<ResearchProject_RTBasicFuses.description>Allows building makeshift fuses; can be placed anywhere on a power network with batteries. Each one is enough to safely dissipate up to 3000 Wd (three standard batteries) discharge, but will require repairs if tripped.</ResearchProject_RTBasicFuses.description>
+	<ResearchProject_RTBasicFuses.description>Allows building Makeshift Fuses; can be placed anywhere on a power network with batteries. Each one is enough to safely dissipate up to 3000 Wd (three standard batteries) discharge, but will require repairs if tripped.</ResearchProject_RTBasicFuses.description>
 
 </LanguageData>

--- a/Mods/RT Fuse_SK/Languages/English/DefInjected/ThingDefs/Building_RTMakeshiftFuse.xml
+++ b/Mods/RT Fuse_SK/Languages/English/DefInjected/ThingDefs/Building_RTMakeshiftFuse.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <LanguageData>
 
-	<Building_RTMakeshiftFuse.label>makeshift fuse</Building_RTMakeshiftFuse.label>
+	<Building_RTMakeshiftFuse.label>Makeshift Fuse</Building_RTMakeshiftFuse.label>
 	<Building_RTMakeshiftFuse.description>A simple fuse. Handles up to 3000 Wd discharge, will require repairs if tripped.</Building_RTMakeshiftFuse.description>
 
 </LanguageData>

--- a/Mods/RT Storage_SK/Defs/ResearchProjectDefs/ResearchProject_RTBasicFuses.xml
+++ b/Mods/RT Storage_SK/Defs/ResearchProjectDefs/ResearchProject_RTBasicFuses.xml
@@ -4,7 +4,7 @@
 	<ResearchProjectDef>
 		<defName>ResearchProject_RTBasicFuses</defName>
 		<label>basic fuses</label>
-		<description>Allows building makeshift fuses; can be placed anywhere on a power network with batteries. Each one is enough to safely dissipate up to 3000 Wd (three standard batteries) discharge, but will require repairs if tripped.</description>
+		<description>Allows building Makeshift Fuses; can be placed anywhere on a power network with batteries. Each one is enough to safely dissipate up to 3000 Wd (three standard batteries) discharge, but will require repairs if tripped.</description>
 		<totalCost>500</totalCost>
 	</ResearchProjectDef>
 

--- a/Mods/RT Storage_SK/Defs/ThingDefs/Building_RTQuantumRelay.xml
+++ b/Mods/RT Storage_SK/Defs/ThingDefs/Building_RTQuantumRelay.xml
@@ -5,7 +5,7 @@
   <ThingDef>
     <defName>Building_RTQuantumRelay</defName>
     <label>Quantum Relay</label>
-    <description>A remote extension for a quantum warehouse - items specified in the filter will be drawn from the warehouse, and applicable adjacent items will be sent back.</description>
+    <description>A remote extension for a Quantum Warehouse. Items specified in the filter will be drawn from the connected warehouse onto the relay and applicable items in an adjacent stockpile zone will be sent to the warehouse.</description>
     <designationCategory>Accessories</designationCategory>
     <category>Building</category>
     <thingClass>Building_Storage</thingClass>

--- a/Mods/RT Storage_SK/Defs/ThingDefs/Building_RTQuantumRelaySmall.xml
+++ b/Mods/RT Storage_SK/Defs/ThingDefs/Building_RTQuantumRelaySmall.xml
@@ -4,7 +4,7 @@
   <ThingDef>
     <defName>Building_RTQuantumRelaySmall</defName>
     <label>Small Quantum Relay</label>
-    <description>A remote extension for a quantum warehouse - items specified in the filter will be drawn from the warehouse, and applicable adjacent items will be sent back.</description>
+    <description>A remote extension for a Quantum Warehouse. Items specified in the filter will be drawn from the connected warehouse onto the relay and applicable items in an adjacent stockpile zone will be sent to the warehouse.</description>
     <designationCategory>Accessories</designationCategory>
     <category>Building</category>
     <thingClass>Building_Storage</thingClass>

--- a/Mods/RT Storage_SK/Defs/ThingDefs/Building_RTQuantumWarehouse.xml
+++ b/Mods/RT Storage_SK/Defs/ThingDefs/Building_RTQuantumWarehouse.xml
@@ -4,7 +4,7 @@
   <ThingDef>
     <defName>Building_RTQuantumWarehouse</defName>
     <label>Quantum Warehouse</label>
-    <description>A supplement to quantum stockpiles, when placed under a stockpile zone will network all quantum stockpiles in the zone to minimize amount of incomplete item stacks and distribute stacks across all quantum stockpile cells.</description>
+    <description>A supplement to Quantum Stockpiles. When placed under a stockpile zone will network all Quantum Stockpiles in the zone to minimize amount of incomplete item stacks and distribute stacks across all Quantum Stockpile cells.</description>
     <designationCategory>Accessories</designationCategory>
     <category>Building</category>
     <thingClass>Building</thingClass>

--- a/Mods/RT Storage_SK/Defs/ThingDefs/Building_RTQuantumWarehouseSmall.xml
+++ b/Mods/RT Storage_SK/Defs/ThingDefs/Building_RTQuantumWarehouseSmall.xml
@@ -4,7 +4,7 @@
   <ThingDef>
     <defName>Building_RTQuantumWarehouseSmall</defName>
     <label>Small Quantum Warehouse</label>
-    <description>A supplement to quantum stockpiles, when placed under a stockpile zone will network all quantum stockpiles in the zone to minimize amount of incomplete item stacks and distribute stacks across all quantum stockpile cells.</description>
+    <description>A supplement to Quantum Stockpiles. When placed under a stockpile zone will network all Quantum Stockpiles in the zone to minimize amount of incomplete item stacks and distribute stacks across all Quantum Stockpile cells.</description>
     <designationCategory>Accessories</designationCategory>
     <category>Building</category>
     <thingClass>Building</thingClass>

--- a/Mods/RT Storage_SK/Languages/English/DefInjected/ThingDefs/Building_RTQuantumRelay.xml
+++ b/Mods/RT Storage_SK/Languages/English/DefInjected/ThingDefs/Building_RTQuantumRelay.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <LanguageData>
 
-  <Building_RTQuantumRelay.label>quantum relay</Building_RTQuantumRelay.label>
-  <Building_RTQuantumRelay.description>A remote extension for a quantum warehouse - items specified in the filter will be drawn from the warehouse, and applicable adjacent items will be sent to it.</Building_RTQuantumRelay.description>
+  <Building_RTQuantumRelay.label>Quantum Relay</Building_RTQuantumRelay.label>
+  <Building_RTQuantumRelay.description>A remote extension for a Quantum Warehouse. Items specified in the filter will be drawn from the connected warehouse onto the relay and applicable items in an adjacent stockpile zone will be sent to the warehouse.</Building_RTQuantumRelay.description>
   
 </LanguageData>

--- a/Mods/RT Storage_SK/Languages/English/DefInjected/ThingDefs/Building_RTQuantumRelaySmall.xml
+++ b/Mods/RT Storage_SK/Languages/English/DefInjected/ThingDefs/Building_RTQuantumRelaySmall.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <LanguageData>
 
-  <Building_RTQuantumRelaySmall.label>small quantum relay</Building_RTQuantumRelaySmall.label>
-  <Building_RTQuantumRelaySmall.description>A remote extension for a quantum warehouse - items specified in the filter will be drawn from the warehouse, and applicable adjacent items will be sent to it.</Building_RTQuantumRelaySmall.description>
+  <Building_RTQuantumRelaySmall.label>Small Quantum Relay</Building_RTQuantumRelaySmall.label>
+  <Building_RTQuantumRelaySmall.description>A remote extension for a Quantum Warehouse. Items specified in the filter will be drawn from the connected warehouse onto the relay and applicable items in an adjacent stockpile zone will be sent to the warehouse.</Building_RTQuantumRelaySmall.description>
   
 </LanguageData>

--- a/Mods/RT Storage_SK/Languages/English/DefInjected/ThingDefs/Building_RTQuantumStockpile.xml
+++ b/Mods/RT Storage_SK/Languages/English/DefInjected/ThingDefs/Building_RTQuantumStockpile.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <LanguageData>
 
-  <Building_RTQuantumStockpile.label>quantum stockpile</Building_RTQuantumStockpile.label>
-  <Building_RTQuantumStockpile.description>An advanced storage solution, when placed under a stockpile zone will attempt to pile up adjacent items on top of itself, well over normal storage limits.</Building_RTQuantumStockpile.description>
+  <Building_RTQuantumStockpile.label>Quantum Stockpile</Building_RTQuantumStockpile.label>
+  <Building_RTQuantumStockpile.description>An advanced storage solution. When placed under a stockpile zone will attempt to pile up adjacent items on top of itself, well over normal storage limits.</Building_RTQuantumStockpile.description>
   
 </LanguageData>

--- a/Mods/RT Storage_SK/Languages/English/DefInjected/ThingDefs/Building_RTQuantumStockpileSmall.xml
+++ b/Mods/RT Storage_SK/Languages/English/DefInjected/ThingDefs/Building_RTQuantumStockpileSmall.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <LanguageData>
 
-  <Building_RTQuantumStockpileSmall.label>small quantum stockpile</Building_RTQuantumStockpileSmall.label>
-  <Building_RTQuantumStockpileSmall.description>An advanced storage solution, when placed under a stockpile zone will attempt to pile up adjacent items on top of itself, well over normal storage limits.</Building_RTQuantumStockpileSmall.description>
+  <Building_RTQuantumStockpileSmall.label>Small Quantum Stockpile</Building_RTQuantumStockpileSmall.label>
+  <Building_RTQuantumStockpileSmall.description>An advanced storage solution. When placed under a stockpile zone will attempt to pile up adjacent items on top of itself, well over normal storage limits.</Building_RTQuantumStockpileSmall.description>
   
 </LanguageData>

--- a/Mods/RT Storage_SK/Languages/English/DefInjected/ThingDefs/Building_RTQuantumWarehouse.xml
+++ b/Mods/RT Storage_SK/Languages/English/DefInjected/ThingDefs/Building_RTQuantumWarehouse.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <LanguageData>
 
-  <Building_RTQuantumWarehouse.label>quantum warehouse</Building_RTQuantumWarehouse.label>
-  <Building_RTQuantumWarehouse.description>A supplement to quantum stockpiles, when placed under a stockpile zone will network all quantum stockpiles in the zone to minimize amount of incomplete item stacks and distribute stacks across all quantum stockpile cells.</Building_RTQuantumWarehouse.description>
+  <Building_RTQuantumWarehouse.label>Quantum Warehouse</Building_RTQuantumWarehouse.label>
+  <Building_RTQuantumWarehouse.description>A supplement to Quantum Stockpiles. When placed under a stockpile zone will network all Quantum Stockpiles in the zone to minimize amount of incomplete item stacks and distribute stacks across all Quantum Stockpile cells.</Building_RTQuantumWarehouse.description>
   
 </LanguageData>

--- a/Mods/RT Storage_SK/Languages/English/DefInjected/ThingDefs/Building_RTQuantumWarehouseSmall.xml
+++ b/Mods/RT Storage_SK/Languages/English/DefInjected/ThingDefs/Building_RTQuantumWarehouseSmall.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <LanguageData>
 
-  <Building_RTQuantumWarehouseSmall.label>small quantum warehouse</Building_RTQuantumWarehouseSmall.label>
-  <Building_RTQuantumWarehouseSmall.description>A supplement to quantum stockpiles, when placed under a stockpile zone will network all quantum stockpiles in the zone to minimize amount of incomplete item stacks and distribute stacks across all quantum stockpile cells.</Building_RTQuantumWarehouseSmall.description>
+  <Building_RTQuantumWarehouseSmall.label>Small Quantum Warehouse</Building_RTQuantumWarehouseSmall.label>
+  <Building_RTQuantumWarehouseSmall.description>A supplement to Quantum Stockpiles. When placed under a stockpile zone will network all Quantum Stockpiles in the zone to minimize amount of incomplete item stacks and distribute stacks across all Quantum Stockpile cells.</Building_RTQuantumWarehouseSmall.description>
   
 
 </LanguageData>

--- a/Mods/RT Storage_SK/Languages/English/Keyed/CompRTQuantumRelay.xml
+++ b/Mods/RT Storage_SK/Languages/English/Keyed/CompRTQuantumRelay.xml
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <LanguageData>
 
-  <CompRTQuantumRelay_QWConnected>Connected quantum warehouse: </CompRTQuantumRelay_QWConnected>
-  <CompRTQuantumRelay_QWIsSelf>Quantum relay is targeting itself!</CompRTQuantumRelay_QWIsSelf>
-  <CompRTQuantumRelay_QWIsNull>Quantum warehouse not selected.</CompRTQuantumRelay_QWIsNull>
+  <CompRTQuantumRelay_QWConnected>Connected Quantum Warehouse: </CompRTQuantumRelay_QWConnected>
+  <CompRTQuantumRelay_QWIsSelf>Quantum Relay is targeting itself!</CompRTQuantumRelay_QWIsSelf>
+  <CompRTQuantumRelay_QWIsNull>Quantum Warehouse not selected.</CompRTQuantumRelay_QWIsNull>
   <CompRTQuantumRelay_SparklesToggle>QR activity indication</CompRTQuantumRelay_SparklesToggle>
   <CompRTQuantumRelay_SparklesAreOn>Enabled</CompRTQuantumRelay_SparklesAreOn>
   <CompRTQuantumRelay_SparkelsAreOff>Disabled</CompRTQuantumRelay_SparkelsAreOff>
   <CompRTQuantumRelay_WarehouseNextLabel>Next QW</CompRTQuantumRelay_WarehouseNextLabel>
-  <CompRTQuantumRelay_WarehouseNextDesc>Select next quantum warehouse.</CompRTQuantumRelay_WarehouseNextDesc>
+  <CompRTQuantumRelay_WarehouseNextDesc>Select Next Quantum Warehouse.</CompRTQuantumRelay_WarehouseNextDesc>
   <CompRTQuantumRelay_WarehousePrevLabel>Previous QW</CompRTQuantumRelay_WarehousePrevLabel>
-  <CompRTQuantumRelay_WarehousePrevDesc>Select previous quantum warehouse.</CompRTQuantumRelay_WarehousePrevDesc>
+  <CompRTQuantumRelay_WarehousePrevDesc>Select Previous Quantum Warehouse.</CompRTQuantumRelay_WarehousePrevDesc>
 
 </LanguageData>

--- a/Mods/RT Storage_SK/Languages/English/Keyed/CompRTQuantumStockpile.xml
+++ b/Mods/RT Storage_SK/Languages/English/Keyed/CompRTQuantumStockpile.xml
@@ -2,7 +2,7 @@
 <LanguageData>
 
   <CompRTQuantumStockpile_SelfDefrag>Self-defragments periodically.</CompRTQuantumStockpile_SelfDefrag>
-  <CompRTQuantumStockpile_QWConnect>Connected to a quantum warehouse.</CompRTQuantumStockpile_QWConnect>
+  <CompRTQuantumStockpile_QWConnect>Connected to a Quantum Warehouse.</CompRTQuantumStockpile_QWConnect>
   <CompRTQuantumStockpile_MaxStacks>Maximum stacks per cell:</CompRTQuantumStockpile_MaxStacks>
   <CompRTQuantumStockpile_SparklesToggle>QS activity indication</CompRTQuantumStockpile_SparklesToggle>
   <CompRTQuantumStockpile_SparklesAreOn>Enabled</CompRTQuantumStockpile_SparklesAreOn>

--- a/Mods/RT Storage_SK/Languages/English/Keyed/CompRTQuantumWarehouse.xml
+++ b/Mods/RT Storage_SK/Languages/English/Keyed/CompRTQuantumWarehouse.xml
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <LanguageData>
 
-  <CompRTQuantumWarehouse_ConnectedQS>Connected quantum stockpiles: </CompRTQuantumWarehouse_ConnectedQS>
-  <CompRTQuantumWarehouse_NotValid>Quantum warehouse already present.</CompRTQuantumWarehouse_NotValid>
-  <CompRTQuantumWarehouse_SparklesToggle>QW activity indication</CompRTQuantumWarehouse_SparklesToggle>
+  <CompRTQuantumWarehouse_ConnectedQS>Connected Quantum Stockpiles: </CompRTQuantumWarehouse_ConnectedQS>
+  <CompRTQuantumWarehouse_NotValid>Quantum Warehouse already present.</CompRTQuantumWarehouse_NotValid>
+  <CompRTQuantumWarehouse_SparklesToggle>QW Activity Indication</CompRTQuantumWarehouse_SparklesToggle>
   <CompRTQuantumWarehouse_SparklesAreOn>Enabled</CompRTQuantumWarehouse_SparklesAreOn>
   <CompRTQuantumWarehouse_SparkelsAreOff>Disabled</CompRTQuantumWarehouse_SparkelsAreOff>
 

--- a/Mods/RT Storage_SK/Languages/English/Keyed/PlaceWorker_RTNoQSOverlap.xml
+++ b/Mods/RT Storage_SK/Languages/English/Keyed/PlaceWorker_RTNoQSOverlap.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <LanguageData>
 
-  <PlaceWorker_RTNoQSOverlap>Quantum stockpiles must not overlap.</PlaceWorker_RTNoQSOverlap>
+  <PlaceWorker_RTNoQSOverlap>Quantum Stockpiles must not overlap.</PlaceWorker_RTNoQSOverlap>
 
 </LanguageData>

--- a/Mods/RT Storage_SK/Languages/English/Keyed/PlaceWorker_RTOnlyOneQWPerZone.xml
+++ b/Mods/RT Storage_SK/Languages/English/Keyed/PlaceWorker_RTOnlyOneQWPerZone.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <LanguageData>
 
-  <PlaceWorker_RTOnlyOneQWPerZone>Only one quantum warehouse per stockpile zone.</PlaceWorker_RTOnlyOneQWPerZone>
+  <PlaceWorker_RTOnlyOneQWPerZone>Only one Quantum Warehouse per stockpile zone.</PlaceWorker_RTOnlyOneQWPerZone>
 
 </LanguageData>

--- a/Mods/RT_SolarFlareShield_SK/Defs/MapConditionDefs/MapCondition_RTSolarFlare.xml
+++ b/Mods/RT_SolarFlareShield_SK/Defs/MapConditionDefs/MapCondition_RTSolarFlare.xml
@@ -4,7 +4,7 @@
 	<MapConditionDef>
 		<defName>MapCondition_RTSolarFlare</defName>
 		<label>shielded solar flare</label>
-		<endMessage>Magnetic shield was overwhelmed.</endMessage>
+		<endMessage>Magnetic Shield was overwhelmed.</endMessage>
 		<description>A solar flare is hitting the planet. A magnetic shield protects most devices from extreme electrical interference that would prevent them from working, although radio communication is impossible.</description>
 	</MapConditionDef>
 

--- a/Mods/RT_SolarFlareShield_SK/Defs/ResearchProjectDefs/ResearchProject_RTMagneticShield.xml
+++ b/Mods/RT_SolarFlareShield_SK/Defs/ResearchProjectDefs/ResearchProject_RTMagneticShield.xml
@@ -4,7 +4,7 @@
 	<ResearchProjectDef>
 		<defName>ResearchProject_RTMagneticShield</defName>
 		<label>solar flare shielding</label>
-		<description>Allows construction of a magnetic shield to protect electric devices in the entire colony from solar flares.
+		<description>Allows construction of a Magnetic Shield to protect electric devices in the entire colony from solar flares.
 		
 When idle, the shield requires a pittance of power to maintain it's detection circuits, ever ready to activate whenever a solar flare occurs. Should that happen, the shield will start drawing up to 25 kWt of power in order to form a semblance of localized magnetosphere, neutralizing the effect a solar flare would have on colony's electronics. Effective range of this protection is enough to cover the colony and then some.
 

--- a/Mods/RT_SolarFlareShield_SK/Languages/English/DefInjected/MapConditionDefs/MapCondition_RTSolarFlare.xml
+++ b/Mods/RT_SolarFlareShield_SK/Languages/English/DefInjected/MapConditionDefs/MapCondition_RTSolarFlare.xml
@@ -2,7 +2,7 @@
 <LanguageData>
 
 	<MapCondition_RTSolarFlare.label>shielded solar flare</MapCondition_RTSolarFlare.label>
-	<MapCondition_RTSolarFlare.endMessage>Magnetic shield was overwhelmed.</MapCondition_RTSolarFlare.endMessage>
+	<MapCondition_RTSolarFlare.endMessage>Magnetic Shield was overwhelmed.</MapCondition_RTSolarFlare.endMessage>
 	<MapCondition_RTSolarFlare.description>A solar flare is hitting the planet. A magnetic shield protects most devices from extreme electrical interference that would prevent them from working, although radio communication is impossible.</MapCondition_RTSolarFlare.description>
 
 </LanguageData>

--- a/Mods/RT_SolarFlareShield_SK/Languages/English/DefInjected/ResearchProjectDefs/ResearchProject_RTMagneticShield.xml
+++ b/Mods/RT_SolarFlareShield_SK/Languages/English/DefInjected/ResearchProjectDefs/ResearchProject_RTMagneticShield.xml
@@ -2,7 +2,7 @@
 <LanguageData>
 
 	<ResearchProject_RTMagneticShield.label>solar flare shielding</ResearchProject_RTMagneticShield.label>
-	<ResearchProject_RTMagneticShield.description>Allows construction of a magnetic shield to protect electric devices in the entire colony from solar flares.
+	<ResearchProject_RTMagneticShield.description>Allows construction of a Magnetic Shield to protect electric devices in the entire colony from solar flares.
 
 When idle, the shield requires a pittance of power to maintain it's detection circuits, ever ready to activate whenever a solar flare occurs. Should that happen, the shield will start drawing up to 25 kWt of power in order to form a semblance of localized magnetosphere, neutralizing the effect a solar flare would have on colony's electronics. Effective range of this protection is enough to cover the colony and then some.
 

--- a/Mods/RT_SolarFlareShield_SK/Languages/English/DefInjected/ThingDefs/Building_RTMagneticShield.xml
+++ b/Mods/RT_SolarFlareShield_SK/Languages/English/DefInjected/ThingDefs/Building_RTMagneticShield.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <LanguageData>
 
-	<Building_RTMagneticShield.label>magnetic shield</Building_RTMagneticShield.label>
+	<Building_RTMagneticShield.label>Magnetic Shield</Building_RTMagneticShield.label>
 	<Building_RTMagneticShield.description>Automatically switches on to protect the entire colony from a solar flare; tremendous power drain and considerable heating when operational.</Building_RTMagneticShield.description>
 
 </LanguageData>

--- a/Mods/RT_SolarFlareShield_SK/Languages/English/Keyed/PlaceWorker_RTOnlyOneShieldOnMap.xml
+++ b/Mods/RT_SolarFlareShield_SK/Languages/English/Keyed/PlaceWorker_RTOnlyOneShieldOnMap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <LanguageData>
 
-	<PlaceWorker_RTOnlyOneShieldOnMap>Only one magnetic shield can be installed!</PlaceWorker_RTOnlyOneShieldOnMap>
+	<PlaceWorker_RTOnlyOneShieldOnMap>Only one Magnetic Shield can be installed!</PlaceWorker_RTOnlyOneShieldOnMap>
 
 </LanguageData>

--- a/Mods/RW_A2B/Defs/ThingDefs/Building_A2B.xml
+++ b/Mods/RW_A2B/Defs/ThingDefs/Building_A2B.xml
@@ -128,7 +128,7 @@
 
     <ThingDef ParentName="A2BMinified">
         <defName>A2BCurve</defName>
-        <label>curved belt</label>
+        <label>Curved Belt</label>
         <thingClass>Building</thingClass>
         <graphicData>
             <texPath>Things/Building/Curve</texPath>

--- a/Mods/RW_A2B/Defs/ThingDefs/Building_A2B2.xml
+++ b/Mods/RW_A2B/Defs/ThingDefs/Building_A2B2.xml
@@ -60,7 +60,7 @@
 
     <ThingDef ParentName="A2B2Minified">
         <defName>A2BUndercover</defName>
-        <label>underground belt</label>
+        <label>Underground Belt</label>
         <thingClass>Building</thingClass>
         <category>Building</category>
         <building>
@@ -85,7 +85,7 @@
         </statBases>
         <altitudeLayer>FloorEmplacement</altitudeLayer>
         <pathCost>1000</pathCost>
-        <description>An underground belt.</description>
+        <description>An underground conveyor belt.</description>
         <passability>Standable</passability>
         <rotatable>false</rotatable>
         <terrainAffordanceNeeded>Heavy</terrainAffordanceNeeded>
@@ -108,7 +108,7 @@
 
     <ThingDef ParentName="A2B2Minified">
         <defName>A2BUndercoverCover</defName>
-        <label>underground belt cover</label>
+        <label>Underground Belt Cover</label>
         <thingClass>Building</thingClass>
         <category>Building</category>
         <selectable>false</selectable>

--- a/Mods/RW_A2B/Languages/English/Keyed/A2B.xml
+++ b/Mods/RW_A2B/Languages/English/Keyed/A2B.xml
@@ -25,7 +25,7 @@
     <A2B_Undertaker_Flow>Flow:</A2B_Undertaker_Flow>
     <A2B_Undertaker_FlowTo>to</A2B_Undertaker_FlowTo>
 
-    <A2B_UndercoverCover_Toggle>Toggle cover</A2B_UndercoverCover_Toggle>
+    <A2B_UndercoverCover_Toggle>Toggle Cover</A2B_UndercoverCover_Toggle>
     <A2B_UnderUndercoverCover_Toggle_Desc>Replace or remove the belt cover</A2B_UnderUndercoverCover_Toggle_Desc>
     <A2B_UnderUndercoverCover_Toggle_DesignateOnly>Can only designate undercovers</A2B_UnderUndercoverCover_Toggle_DesignateOnly>
     

--- a/Mods/RW_Manager-0.13.0.2/Defs/ResearchProjectDefs/ManagerStations_Research.xml
+++ b/Mods/RW_Manager-0.13.0.2/Defs/ResearchProjectDefs/ManagerStations_Research.xml
@@ -7,7 +7,7 @@
         <description>
 Develop basic software for colony management. 
 
-Allows building manager desks with a computer, pre-installed with a host of guaranteed bug free(tm) managing software.
+Allows building Manager Desks with a computer, pre-installed with a host of guaranteed bug free(tm) managing software.
         </description>
         <totalCost>1500</totalCost>
         <prerequisites>

--- a/Mods/RW_Manager-0.13.0.2/Defs/ThingDefs/Buildings_ManagerStation.xml
+++ b/Mods/RW_Manager-0.13.0.2/Defs/ThingDefs/Buildings_ManagerStation.xml
@@ -62,7 +62,7 @@
 
 	<ThingDef ParentName="BenchBase">
 		<DefName>FM_BasicManagerStation</DefName>
-		<label>basic manager desk</label>
+		<label>Basic Manager Desk</label>
 		<ThingClass>FluffyManager.Building_ManagerStation</ThingClass>
 		<Description>A simple table with all the stationary required to allow a manager to do his work.</Description>
 		<graphicData>
@@ -106,7 +106,7 @@
 
 	<ThingDef ParentName="BenchBase">
 		<DefName>FM_ManagerStation</DefName>
-		<label>manager desk</label>
+		<label>Manager Desk</label>
 		<ThingClass>FluffyManager.Building_ManagerStation</ThingClass>
 		<Description>A desk with a computer and all the stationary required to allow a manager to do his work efficiently.</Description>
 		<graphicData>
@@ -160,7 +160,7 @@
 
 	<ThingDef ParentName="BenchBase">
 		<DefName>FM_AIManager</DefName>
-		<label>AI manager</label>
+		<label>AI Manager</label>
 		<ThingClass>FluffyManager.Building_AIManager</ThingClass>
 		<Description>An enormous supercomputer capable of autonously managing your colony. Claims that the AI has a malevolent psychopath subroutine are entirely false. We promise.</Description>
 		<graphicData>


### PR DESCRIPTION
A ton of capitalization and spelling fixes for UI polish and uniformity. Only labels and descriptions were touched.

Fixed some weapon crate descriptions because they referenced the old name of the item before the original author renamed it.

Also renamed `Glass Table` to simply `Table` because it was producing `Glass Table Table` and `Reinforced Glass Table Table`. :>
